### PR TITLE
feat(staykey): add Matter lock support and protocol-agnostic lock provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.9](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.8...v1.6.0-beta.9) (2026-05-06)
+
+
+### Features
+
+* **staykey:** enhance user status handling for lock credential management ([474f3a9](https://github.com/staykey/staykey-ha-plugin/commit/474f3a9a404cdacdb5565134cdcd3835657c40bd))
+
 ## [1.6.0-beta.8](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.7...v1.6.0-beta.8) (2026-05-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.2](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.1...v1.6.0-beta.2) (2026-05-05)
+
+
+### Features
+
+* **staykey:** improve Matter lock credential handling and error reporting ([b46fbe6](https://github.com/staykey/staykey-ha-plugin/commit/b46fbe6ac841d8a493b04ed71cf20c0f5baf1052))
+
 ## [1.6.0-beta.1](https://github.com/staykey/staykey-ha-plugin/compare/v1.5.0...v1.6.0-beta.1) (2026-05-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@
 
 ### Features
 
-* **staykey:** add list_entities action to handle entity listing for Orion endpoint ([7f21cb0](https://github.com/staykey/staykey-ha-plugin/commit/7f21cb065d67885b7c8d8d445554e28daaf28fee))
+* **staykey:** add list_entities action to handle entity listing for the Staykey integration ([7f21cb0](https://github.com/staykey/staykey-ha-plugin/commit/7f21cb065d67885b7c8d8d445554e28daaf28fee))
 
 ## [1.3.0-beta.8](https://github.com/staykey/staykey-ha-plugin/compare/v1.3.0-beta.7...v1.3.0-beta.8) (2026-03-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.4](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.3...v1.6.0-beta.4) (2026-05-06)
+
+
+### Bug Fixes
+
+* **staykey:** refine credential handling for Matter locks ([dde9ee5](https://github.com/staykey/staykey-ha-plugin/commit/dde9ee5316cad7c482ac1f1292c05ce21c1fb4d1))
+
 ## [1.6.0-beta.3](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.2...v1.6.0-beta.3) (2026-05-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.6](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.5...v1.6.0-beta.6) (2026-05-06)
+
+
+### Features
+
+* **staykey:** enhance capability info with max users and credentials ([5feee78](https://github.com/staykey/staykey-ha-plugin/commit/5feee78f4b1cb79a06a84258cdb196d913d81bd8))
+
 ## [1.6.0-beta.5](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.4...v1.6.0-beta.5) (2026-05-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.3](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.2...v1.6.0-beta.3) (2026-05-06)
+
+
+### Bug Fixes
+
+* **staykey:** correct handling of user status and type in SetCredential ([28b1045](https://github.com/staykey/staykey-ha-plugin/commit/28b104536dd3d4dffdf2e607144e03bc07ae68cc))
+
 ## [1.6.0-beta.2](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.1...v1.6.0-beta.2) (2026-05-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.1](https://github.com/staykey/staykey-ha-plugin/compare/v1.5.0...v1.6.0-beta.1) (2026-05-05)
+
+
+### Features
+
+* **staykey:** enhance lock handling with protocol-specific providers ([eb432fe](https://github.com/staykey/staykey-ha-plugin/commit/eb432fed11665e9a32f96b24e5094cb41d79b130))
+
 ## [1.5.0](https://github.com/staykey/staykey-ha-plugin/compare/v1.4.0...v1.5.0) (2026-04-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.10](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.9...v1.6.0-beta.10) (2026-05-07)
+
+
+### Bug Fixes
+
+* **staykey:** omit user_status from Matter SetCredential add payload ([397f13e](https://github.com/staykey/staykey-ha-plugin/commit/397f13e67a99160f87348cffcdfe97f36e8c3400))
+
 ## [1.6.0-beta.9](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.8...v1.6.0-beta.9) (2026-05-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.5](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.4...v1.6.0-beta.5) (2026-05-06)
+
+
+### Features
+
+* **staykey:** add matter capacity awareness and ha_service_call passthrough ([06b9fcb](https://github.com/staykey/staykey-ha-plugin/commit/06b9fcb7292c35f39b4ebf79dae7f7786fac8da3))
+
 ## [1.6.0-beta.4](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.3...v1.6.0-beta.4) (2026-05-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.8](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.7...v1.6.0-beta.8) (2026-05-06)
+
+
+### Features
+
+* **staykey:** add tap_events action to handle event taps ([5e2c33a](https://github.com/staykey/staykey-ha-plugin/commit/5e2c33ac05ec5570b316ca2033069d0486ea0bba))
+
 ## [1.6.0-beta.7](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.6...v1.6.0-beta.7) (2026-05-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.13](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.12...v1.6.0-beta.13) (2026-05-07)
+
+
+### Features
+
+* **staykey:** enhance Matter lock capability handling and documentation ([6d836cf](https://github.com/staykey/staykey-ha-plugin/commit/6d836cf6a64ee26911bbc678804e05164aa8118b))
+
 ## [1.6.0-beta.12](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.11...v1.6.0-beta.12) (2026-05-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.11](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.10...v1.6.0-beta.11) (2026-05-07)
+
+
+### Bug Fixes
+
+* **staykey:** simplify SetCredential logic for Matter locks ([c6d4b25](https://github.com/staykey/staykey-ha-plugin/commit/c6d4b25d69132bec438dcc796c50fb25b00208a2))
+
 ## [1.6.0-beta.10](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.9...v1.6.0-beta.10) (2026-05-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.12](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.11...v1.6.0-beta.12) (2026-05-07)
+
+
+### Features
+
+* **staykey:** remove max_users and max_credentials_per_user from capability handling ([6e6aeb4](https://github.com/staykey/staykey-ha-plugin/commit/6e6aeb4f44fc21523420fdad3f15ecefc0499b1e))
+
 ## [1.6.0-beta.11](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.10...v1.6.0-beta.11) (2026-05-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.6.0-beta.7](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.6...v1.6.0-beta.7) (2026-05-06)
+
+
+### Bug Fixes
+
+* **staykey:** improve PIN slot capacity calculation and documentation ([e567a3c](https://github.com/staykey/staykey-ha-plugin/commit/e567a3cdc8701ba4aae4d8b5bc65d6f2280aed21))
+
 ## [1.6.0-beta.6](https://github.com/staykey/staykey-ha-plugin/compare/v1.6.0-beta.5...v1.6.0-beta.6) (2026-05-06)
 
 

--- a/README.md
+++ b/README.md
@@ -95,3 +95,4 @@ This repository uses semantic versioning with automated releases:
 2. The release workflow computes the next version, updates `CHANGELOG.md` and `manifest.json`, creates a GitHub release, and tags it
 
 HACS detects new releases automatically from GitHub tags.
+

--- a/custom_components/staykey/__init__.py
+++ b/custom_components/staykey/__init__.py
@@ -450,6 +450,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 hass.bus.async_listen(event_type, handle_zwave_event_gateway)
             )
 
+    # KNOWN LIMITATION (early Matter lock support):
+    #
+    # Matter devices can produce detailed per-credential lock-operation
+    # events, but Home Assistant's Matter integration (through 2026.4) does
+    # not yet expose them on hass.bus like Z-Wave notification events.
+    # The entity mostly updates `locked`/`unlocked`, so forwarded
+    # `lock_activity` is lower fidelity than Z-Wave. Programming operations
+    # still return structured success/failure in their service responses;
+    # richer keypad history awaits upstream HA event coverage.
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "unsub": unsubscribers,
         "gateway_client": gateway_client,

--- a/custom_components/staykey/handlers/capability.py
+++ b/custom_components/staykey/handlers/capability.py
@@ -27,11 +27,31 @@ async def handle_get_capabilities(
     device_map: DeviceMap,
     params: Dict[str, Any],
 ) -> Dict[str, Any]:
-    """Get detailed capability information for a device."""
+    """Get detailed capability information for a device.
+
+    Accepts ``external_id`` (the HA entity_id, used by Orion's worker
+    paths and the gateway internal API) **or** ``device_id`` (the
+    Staykey UUID, used by dashboard paths that go through the device
+    map).  This mirrors the dual-key resolution in
+    :mod:`..handlers.lock` so callers don't need to know which key
+    convention applies.
+    """
+    external_id = params.get("external_id", "")
     device_id = params.get("device_id", "")
-    entity_id = device_map.get_entity_id(device_id)
-    if not entity_id:
-        raise ValueError(f"Unknown device_id: {device_id}")
+
+    entity_id: str
+    if external_id:
+        entity_id = external_id
+        if not device_id:
+            device_id = device_map.get_device_id(entity_id) or ""
+    else:
+        entity_id = device_map.get_entity_id(device_id) or ""
+        if not entity_id:
+            raise ValueError(
+                "get_capabilities: provide external_id (entity_id) or a "
+                f"device_id known to the device map; got "
+                f"device_id={device_id!r}"
+            )
 
     capabilities: Dict[str, Any] = {
         "device_id": device_id,

--- a/custom_components/staykey/handlers/capability.py
+++ b/custom_components/staykey/handlers/capability.py
@@ -78,12 +78,6 @@ async def handle_get_capabilities(
             capabilities["supports_access_codes"] = caps.supports_access_codes
             if caps.max_slots is not None:
                 capabilities["max_slots"] = caps.max_slots
-            if caps.max_users is not None:
-                capabilities["max_users"] = caps.max_users
-            if caps.max_credentials_per_user is not None:
-                capabilities["max_credentials_per_user"] = (
-                    caps.max_credentials_per_user
-                )
             if caps.extra:
                 capabilities[provider.name] = caps.extra
             return capabilities

--- a/custom_components/staykey/handlers/capability.py
+++ b/custom_components/staykey/handlers/capability.py
@@ -78,6 +78,12 @@ async def handle_get_capabilities(
             capabilities["supports_access_codes"] = caps.supports_access_codes
             if caps.max_slots is not None:
                 capabilities["max_slots"] = caps.max_slots
+            if caps.max_users is not None:
+                capabilities["max_users"] = caps.max_users
+            if caps.max_credentials_per_user is not None:
+                capabilities["max_credentials_per_user"] = (
+                    caps.max_credentials_per_user
+                )
             if caps.extra:
                 capabilities[provider.name] = caps.extra
             return capabilities

--- a/custom_components/staykey/handlers/capability.py
+++ b/custom_components/staykey/handlers/capability.py
@@ -1,6 +1,10 @@
 """Device capability discovery handler.
 
-Inspects Z-Wave nodes for supported command classes, code slot count, etc.
+For lock entities, capability is sourced from the protocol-specific
+:class:`LockProvider <..services.lock_provider.LockProvider>` so Matter
+locks (HA 2026.4 lock manager) report PIN support correctly.  For other
+domains we still expose Z-Wave node info when present, but without
+hard-failing on Matter / Wi-Fi / Zigbee devices.
 """
 
 from __future__ import annotations
@@ -11,7 +15,9 @@ from typing import Any, Dict
 from homeassistant.core import HomeAssistant
 
 from ..device_map import DeviceMap
-from ..services import zwave
+from ..services import providers
+from ..services.lock_provider import UnsupportedProtocolError
+from ..services.providers import zwave as zwave_provider
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,8 +32,6 @@ async def handle_get_capabilities(
     entity_id = device_map.get_entity_id(device_id)
     if not entity_id:
         raise ValueError(f"Unknown device_id: {device_id}")
-
-    node_info = await zwave.get_node_info(hass, entity_id)
 
     capabilities: Dict[str, Any] = {
         "device_id": device_id,
@@ -46,6 +50,27 @@ async def handle_get_capabilities(
         if "device_class" in attrs:
             capabilities["device_class"] = attrs["device_class"]
 
+    if entity_id.startswith("lock."):
+        try:
+            provider = providers.select_provider(hass, entity_id)
+            caps = await provider.get_capabilities(hass, entity_id)
+            capabilities["protocol"] = provider.name
+            capabilities["supports_access_codes"] = caps.supports_access_codes
+            if caps.max_slots is not None:
+                capabilities["max_slots"] = caps.max_slots
+            if caps.extra:
+                capabilities[provider.name] = caps.extra
+            return capabilities
+        except UnsupportedProtocolError:
+            LOGGER.debug(
+                "No LockProvider for %s; falling back to legacy zwave info",
+                entity_id,
+            )
+
+    # Non-lock domains, or locks on integrations we don't have a provider
+    # for: best-effort Z-Wave node lookup (returns None on Matter / Wi-Fi
+    # / Zigbee devices, which is fine).
+    node_info = await zwave_provider.get_node_info(hass, entity_id)
     if node_info:
         capabilities["zwave"] = node_info
 

--- a/custom_components/staykey/handlers/capability.py
+++ b/custom_components/staykey/handlers/capability.py
@@ -29,12 +29,9 @@ async def handle_get_capabilities(
 ) -> Dict[str, Any]:
     """Get detailed capability information for a device.
 
-    Accepts ``external_id`` (the HA entity_id, used by Orion's worker
-    paths and the gateway internal API) **or** ``device_id`` (the
-    Staykey UUID, used by dashboard paths that go through the device
-    map).  This mirrors the dual-key resolution in
-    :mod:`..handlers.lock` so callers don't need to know which key
-    convention applies.
+    Accepts ``external_id`` (the HA ``entity_id``) **or** ``device_id``
+    (resolved through the device map). Matches the dual-key convention in
+    :mod:`..handlers.lock`.
     """
     external_id = params.get("external_id", "")
     device_id = params.get("device_id", "")

--- a/custom_components/staykey/handlers/cover.py
+++ b/custom_components/staykey/handlers/cover.py
@@ -15,7 +15,7 @@ from .utils import ProgressFn, wait_for_state
 
 LOGGER = logging.getLogger(__name__)
 
-_COVER_STATE_TIMEOUT = 30  # seconds — matches Orion backend
+_COVER_STATE_TIMEOUT = 30  # seconds — aligned with Staykey API timeouts
 
 
 async def handle_open_cover(

--- a/custom_components/staykey/handlers/device_discovery.py
+++ b/custom_components/staykey/handlers/device_discovery.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from ..lock_capability_heuristics import lock_supports_access_codes
+
 LOGGER = logging.getLogger(__name__)
 
 SUPPORTED_DOMAINS = {"lock", "climate", "light", "cover", "sensor", "switch"}
@@ -72,7 +74,9 @@ async def handle_discover_devices(
         state = hass.states.get(entry.entity_id)
         if state and state.attributes:
             entity_info["capabilities"] = _extract_capabilities(
-                entry.domain, state.attributes
+                entry.domain,
+                state.attributes,
+                protocol=entity_info.get("protocol"),
             )
 
         entities_out.append(entity_info)
@@ -98,14 +102,14 @@ def _infer_protocol(device: Any) -> str | None:
     return None
 
 
-def _extract_capabilities(domain: str, attributes: dict) -> list[str]:
+def _extract_capabilities(
+    domain: str, attributes: dict, protocol: str | None = None
+) -> list[str]:
     caps: list[str] = []
     if domain == "lock":
         caps.extend(["lock", "unlock"])
-        if "supported_features" in attributes:
-            features = attributes["supported_features"]
-            if isinstance(features, int) and features & 1:
-                caps.append("access_codes")
+        if lock_supports_access_codes(attributes, protocol):
+            caps.append("access_codes")
     elif domain == "climate":
         caps.extend(["set_temperature", "set_hvac_mode"])
     elif domain == "light":

--- a/custom_components/staykey/handlers/diagnostics.py
+++ b/custom_components/staykey/handlers/diagnostics.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from homeassistant.core import HomeAssistant
 
 from ..device_map import DeviceMap
-from ..services import zwave
+from ..services.providers import zwave as zwave_provider
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ async def handle_get_diagnostics(
             state.last_updated.isoformat() if state.last_updated else None
         )
 
-    node_info = await zwave.get_node_info(hass, entity_id)
+    node_info = await zwave_provider.get_node_info(hass, entity_id)
     if node_info:
         diagnostics["zwave_status"] = node_info.get("status", "unknown")
         diagnostics["zwave_ready"] = node_info.get("ready", False)

--- a/custom_components/staykey/handlers/event_tap.py
+++ b/custom_components/staykey/handlers/event_tap.py
@@ -1,32 +1,24 @@
-"""Bus event tap for ad-hoc HA event observation.
+"""Bus event tap for ad-hoc Home Assistant event observation.
 
 Subscribes to ``hass.bus`` for a bounded duration and returns whatever
-fired during that window.  Useful for empirical investigation of
-vendor-specific Matter / Z-Wave behavior — e.g. "what does HA emit when
-the Bolt SE is unlocked with a PIN?" — where service-call passthrough
-isn't enough because lock operations surface as bus events
-(``state_changed``, integration-specific ``matter_event`` /
-``zwave_js_event``, etc.) rather than service responses.
+fired during that window. Useful when investigating integration behavior —
+e.g. which bus events fire for a keypad unlock — where a service call
+alone does not surface asynchronous notifications.
 
 ## Why this exists
 
-The ``ha_service_call`` passthrough is great for "fire X and tell me
-the response", but events fired *asynchronously* by integrations
-(state changes, Matter cluster events, Z-Wave notifications) never
-flow back through a service-call return value — they go on the
-``hass.bus``.  Subscribing from inside HA is the only way to observe
-them; doing it from outside HA via the gateway requires this kind of
-short-lived, bounded tap.
+Service-call responses carry only direct results; many integrations emit
+follow-on events (``state_changed``, integration-specific notifications).
+Subscribing from inside this component is the reliable way to capture
+those when troubleshooting from a gateway-connected client.
 
-We deliberately keep this tightly scoped (max duration, max event
-count) so a runaway caller can't park a long-lived listener through
-the gateway.
+Windows are capped (duration + max event count) so a misbehaving caller
+cannot leave listeners attached indefinitely.
 
 ## Security model
 
-Same as :mod:`.passthrough` — gated by gateway WebSocket auth, not
-exposed via REST webhooks, and only as privileged as the HA process
-Staykey runs inside.
+Same as :mod:`..passthrough` — gateway-authenticated channel only, not on
+the public REST webhook surface, privilege bounded by the HA integration.
 """
 
 from __future__ import annotations
@@ -58,7 +50,7 @@ async def handle_tap_events(
 
         {
           "event_types": ["state_changed", "matter_event"],  # optional
-          "entity_id": "lock.ultraloq_bolt",                  # optional
+          "entity_id": "lock.front_door",                   # optional filter
           "duration_seconds": 10,                              # default 10, max 60
           "max_events": 200                                     # default 200, max 500
         }
@@ -209,8 +201,7 @@ def _serialize_event(event: Any) -> Dict[str, Any]:
 
     HA's ``Event`` carries ``data`` (a dict, often containing rich
     objects like ``State``, ``datetime``, etc.) and metadata.  We
-    serialize everything into JSON-friendly primitives so the gateway
-    transport doesn't choke.
+    serialize everything into JSON-friendly primitives for transport.
     """
     payload: Dict[str, Any] = {
         "event_type": getattr(event, "event_type", None),

--- a/custom_components/staykey/handlers/event_tap.py
+++ b/custom_components/staykey/handlers/event_tap.py
@@ -1,0 +1,298 @@
+"""Bus event tap for ad-hoc HA event observation.
+
+Subscribes to ``hass.bus`` for a bounded duration and returns whatever
+fired during that window.  Useful for empirical investigation of
+vendor-specific Matter / Z-Wave behavior — e.g. "what does HA emit when
+the Bolt SE is unlocked with a PIN?" — where service-call passthrough
+isn't enough because lock operations surface as bus events
+(``state_changed``, integration-specific ``matter_event`` /
+``zwave_js_event``, etc.) rather than service responses.
+
+## Why this exists
+
+The ``ha_service_call`` passthrough is great for "fire X and tell me
+the response", but events fired *asynchronously* by integrations
+(state changes, Matter cluster events, Z-Wave notifications) never
+flow back through a service-call return value — they go on the
+``hass.bus``.  Subscribing from inside HA is the only way to observe
+them; doing it from outside HA via the gateway requires this kind of
+short-lived, bounded tap.
+
+We deliberately keep this tightly scoped (max duration, max event
+count) so a runaway caller can't park a long-lived listener through
+the gateway.
+
+## Security model
+
+Same as :mod:`.passthrough` — gated by gateway WebSocket auth, not
+exposed via REST webhooks, and only as privileged as the HA process
+Staykey runs inside.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, Iterable, List, Optional
+
+from homeassistant.core import HomeAssistant
+
+LOGGER = logging.getLogger(__name__)
+
+# Hard caps: protect HA from a misbehaving caller.  Tap windows are
+# meant for empirical debugging, not long-running subscriptions.
+_MAX_DURATION_SECONDS = 60.0
+_DEFAULT_DURATION_SECONDS = 10.0
+_MAX_EVENTS = 500
+_DEFAULT_MAX_EVENTS = 200
+
+
+async def handle_tap_events(
+    hass: HomeAssistant,
+    device_map: Any,  # noqa: ARG001 - kept for handler signature uniformity
+    params: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Listen on ``hass.bus`` for *duration_seconds* and return events.
+
+    Expected ``params`` shape::
+
+        {
+          "event_types": ["state_changed", "matter_event"],  # optional
+          "entity_id": "lock.ultraloq_bolt",                  # optional
+          "duration_seconds": 10,                              # default 10, max 60
+          "max_events": 200                                     # default 200, max 500
+        }
+
+    Filtering rules:
+
+    * ``event_types`` is a list of bus event names.  If omitted /
+      empty, the tap subscribes to **all** events via HA's
+      ``MATCH_ALL`` (``"*"``) sentinel — useful for fishing trips.
+    * ``entity_id``, when set, filters returned events to those whose
+      ``data.entity_id`` matches.  Applied post-capture so we don't
+      need to know the schema of every event type up front.
+
+    Returns::
+
+        {
+          "duration_seconds": <actual capture window>,
+          "subscribed_event_types": ["state_changed", ...] | "*",
+          "captured": <count returned>,
+          "truncated": true|false,
+          "events": [
+            {
+              "event_type": "state_changed",
+              "time_fired": "2026-05-06T05:30:00.123456+00:00",
+              "origin": "LOCAL",
+              "context": {"id": "...", "user_id": null, "parent_id": null},
+              "data": { ... }
+            },
+            ...
+          ]
+        }
+    """
+    duration_seconds = _coerce_duration(params.get("duration_seconds"))
+    max_events = _coerce_max_events(params.get("max_events"))
+    event_types = _coerce_event_types(params.get("event_types"))
+    entity_id_filter = params.get("entity_id")
+    if entity_id_filter is not None and not isinstance(entity_id_filter, str):
+        raise ValueError("tap_events: 'entity_id' must be a string when provided")
+
+    captured: List[Dict[str, Any]] = []
+    truncated = False
+    unsubs: List[Any] = []
+
+    def _record(event: Any) -> None:
+        nonlocal truncated
+        if len(captured) >= max_events:
+            truncated = True
+            return
+        captured.append(_serialize_event(event))
+
+    try:
+        if event_types is None:
+            # Subscribe to everything.  HA accepts ``MATCH_ALL`` ("*") as
+            # the wildcard sentinel for ``async_listen``.
+            unsubs.append(hass.bus.async_listen("*", _record))
+            subscribed_label: Any = "*"
+        else:
+            for et in event_types:
+                unsubs.append(hass.bus.async_listen(et, _record))
+            subscribed_label = list(event_types)
+
+        LOGGER.info(
+            "tap_events start duration_seconds=%.1f max_events=%d "
+            "subscribed_event_types=%s entity_id_filter=%s",
+            duration_seconds,
+            max_events,
+            subscribed_label,
+            entity_id_filter,
+        )
+
+        await asyncio.sleep(duration_seconds)
+    finally:
+        for unsub in unsubs:
+            try:
+                unsub()
+            except Exception:  # pragma: no cover - HA returns plain callables
+                LOGGER.exception("tap_events: unsubscribe raised")
+
+    if entity_id_filter is not None:
+        filtered = [
+            e
+            for e in captured
+            if isinstance(e.get("data"), dict)
+            and e["data"].get("entity_id") == entity_id_filter
+        ]
+    else:
+        filtered = captured
+
+    LOGGER.info(
+        "tap_events done captured=%d returned=%d truncated=%s",
+        len(captured),
+        len(filtered),
+        truncated,
+    )
+
+    return {
+        "duration_seconds": duration_seconds,
+        "subscribed_event_types": subscribed_label,
+        "captured": len(filtered),
+        "truncated": truncated,
+        "events": filtered,
+    }
+
+
+def _coerce_duration(value: Any) -> float:
+    if value is None:
+        return _DEFAULT_DURATION_SECONDS
+    try:
+        d = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("tap_events: 'duration_seconds' must be a number") from exc
+    if d <= 0:
+        raise ValueError("tap_events: 'duration_seconds' must be > 0")
+    if d > _MAX_DURATION_SECONDS:
+        # Clamp rather than reject — easier to reason about for callers
+        # that pass "hopefully a long time".
+        return _MAX_DURATION_SECONDS
+    return d
+
+
+def _coerce_max_events(value: Any) -> int:
+    if value is None:
+        return _DEFAULT_MAX_EVENTS
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError("tap_events: 'max_events' must be an integer")
+    if value <= 0:
+        raise ValueError("tap_events: 'max_events' must be > 0")
+    return min(value, _MAX_EVENTS)
+
+
+def _coerce_event_types(value: Any) -> Optional[List[str]]:
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError("tap_events: 'event_types' must be a list of strings")
+    out: List[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item:
+            raise ValueError("tap_events: 'event_types' entries must be non-empty strings")
+        out.append(item)
+    if not out:
+        return None
+    return out
+
+
+def _serialize_event(event: Any) -> Dict[str, Any]:
+    """Produce a JSON-safe representation of an HA Event.
+
+    HA's ``Event`` carries ``data`` (a dict, often containing rich
+    objects like ``State``, ``datetime``, etc.) and metadata.  We
+    serialize everything into JSON-friendly primitives so the gateway
+    transport doesn't choke.
+    """
+    payload: Dict[str, Any] = {
+        "event_type": getattr(event, "event_type", None),
+        "time_fired": _isoformat(getattr(event, "time_fired", None)),
+        "origin": _origin_name(getattr(event, "origin", None)),
+        "context": _serialize_context(getattr(event, "context", None)),
+        "data": _make_serializable(getattr(event, "data", None)),
+    }
+    return payload
+
+
+def _serialize_context(ctx: Any) -> Optional[Dict[str, Any]]:
+    if ctx is None:
+        return None
+    return {
+        "id": getattr(ctx, "id", None),
+        "user_id": getattr(ctx, "user_id", None),
+        "parent_id": getattr(ctx, "parent_id", None),
+    }
+
+
+def _origin_name(origin: Any) -> Optional[str]:
+    if origin is None:
+        return None
+    # HA's EventOrigin is an Enum; ``.value`` is the canonical string
+    # ("local" or "remote").  Fall back to ``str()`` for any custom
+    # origin objects.
+    return getattr(origin, "value", None) or str(origin)
+
+
+def _isoformat(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    iso = getattr(value, "isoformat", None)
+    if callable(iso):
+        try:
+            return iso()
+        except Exception:  # pragma: no cover - defensive
+            return str(value)
+    return str(value)
+
+
+def _make_serializable(value: Any) -> Any:
+    """Recursively convert ``value`` to JSON-serializable primitives.
+
+    Mirrors the conversion in :mod:`.state` so event data is rendered
+    consistently.  Unknown objects fall back to ``str()`` rather than
+    raising — the tap is for human inspection, not strict schemas.
+    """
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_make_serializable(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _make_serializable(v) for k, v in value.items()}
+    iso = getattr(value, "isoformat", None)
+    if callable(iso):
+        try:
+            return iso()
+        except Exception:  # pragma: no cover - defensive
+            pass
+    as_dict = getattr(value, "as_dict", None)
+    if callable(as_dict):
+        try:
+            return _make_serializable(as_dict())
+        except Exception:  # pragma: no cover - defensive
+            pass
+    return str(value)
+
+
+# Internal helpers exposed for testing.
+__all__ = [
+    "handle_tap_events",
+    "_coerce_duration",
+    "_coerce_max_events",
+    "_coerce_event_types",
+    "_serialize_event",
+    "_make_serializable",
+]
+
+
+# Note for callers: ``Iterable[str]`` is accepted via ``_coerce_event_types``
+# but the return is always materialized to a list before subscription so we
+# don't accidentally consume a generator more than once.
+_ = Iterable  # keep import meaningful even if not directly referenced

--- a/custom_components/staykey/handlers/lock.py
+++ b/custom_components/staykey/handlers/lock.py
@@ -20,7 +20,7 @@ from .utils import ProgressFn, wait_for_state
 
 LOGGER = logging.getLogger(__name__)
 
-_LOCK_STATE_TIMEOUT = 15  # seconds — matches Orion backend
+_LOCK_STATE_TIMEOUT = 15  # seconds — aligned with Staykey API timeouts
 
 
 async def handle_lock(
@@ -114,23 +114,6 @@ async def handle_read_codes(
     return {"slots": [_slot_info_to_dict(s) for s in slots]}
 
 
-async def handle_lock_capabilities(
-    hass: HomeAssistant,
-    device_map: DeviceMap,
-    params: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Get protocol-aware capability info for a lock entity."""
-    entity_id = _resolve_entity_id(device_map, params)
-    provider = providers.select_provider(hass, entity_id)
-    caps = await provider.get_capabilities(hass, entity_id)
-    return {
-        "protocol": provider.name,
-        "supports_access_codes": caps.supports_access_codes,
-        "max_slots": caps.max_slots,
-        "extra": caps.extra,
-    }
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -139,9 +122,9 @@ async def handle_lock_capabilities(
 def _resolve_entity_id(device_map: DeviceMap, params: Dict[str, Any]) -> str:
     """Resolve HA entity_id from either ``external_id`` or ``device_id``.
 
-    Orion sends ``external_id`` (the HA entity_id) for worker-driven
-    actions, while dashboard actions send ``device_id`` (Staykey internal
-    UUID that needs a device_map lookup).  Accept both conventions.
+    Remote/API requests often send ``external_id`` (the HA ``entity_id``)
+    directly; others send ``device_id`` (a Staykey-side identifier resolved
+    via the device map). Accept both conventions.
     """
     external_id = params.get("external_id", "")
     if external_id:
@@ -182,6 +165,19 @@ def _provider_result_to_dict(result: ProviderResult) -> Dict[str, Any]:
         out["error"] = result.error
     if result.extra:
         out["extra"] = result.extra
+
+    # Promote structured Matter fields so upstream consumers can classify
+    # failures from stable keys instead of parsing localized `error` text.
+    extra = result.extra or {}
+    matter_status = extra.get("matter_status")
+    if matter_status:
+        out["matter_status"] = matter_status
+
+    # Same for coarse-grained reasons (`slot_out_of_range`, etc.).
+    reason = extra.get("reason")
+    if reason:
+        out["reason"] = reason
+
     return out
 
 

--- a/custom_components/staykey/handlers/lock.py
+++ b/custom_components/staykey/handlers/lock.py
@@ -1,6 +1,9 @@
 """Lock/unlock and access code command handlers.
 
-Translates Staykey-owned schemas to HA service calls.
+Translates Staykey-owned schemas to HA service calls.  Access-code
+operations are delegated to a protocol-specific
+:class:`LockProvider <..services.lock_provider.LockProvider>` selected
+from the device-registry identifiers behind the entity (Z-Wave, Matter, ...).
 """
 
 from __future__ import annotations
@@ -11,6 +14,8 @@ from typing import Any, Dict, Optional
 from homeassistant.core import HomeAssistant
 
 from ..device_map import DeviceMap
+from ..services import providers
+from ..services.lock_provider import ProviderResult, SlotInfo
 from .utils import ProgressFn, wait_for_state
 
 LOGGER = logging.getLogger(__name__)
@@ -36,10 +41,7 @@ async def handle_lock(
     status = await wait_for_state(
         hass, entity_id, "locked", _LOCK_STATE_TIMEOUT, progress_fn=progress_fn,
     )
-    return {
-        "state": status,
-        "method": "remote",
-    }
+    return {"state": status, "method": "remote"}
 
 
 async def handle_unlock(
@@ -64,10 +66,7 @@ async def handle_unlock(
     status = await wait_for_state(
         hass, entity_id, "unlocked", _LOCK_STATE_TIMEOUT, progress_fn=progress_fn,
     )
-    return {
-        "state": status,
-        "method": "remote",
-    }
+    return {"state": status, "method": "remote"}
 
 
 async def handle_set_access_code(
@@ -75,31 +74,13 @@ async def handle_set_access_code(
     device_map: DeviceMap,
     params: Dict[str, Any],
 ) -> Dict[str, Any]:
-    """Set an access code on a lock. Uses zwave_js service for Z-Wave locks."""
+    """Set an access code on a lock via the protocol-appropriate provider."""
     entity_id = _resolve_entity_id(device_map, params)
+    slot, code = _resolve_slot_and_code(params)
 
-    slot = params.get("slot") or params.get("code_slot")
-    code = params.get("code") or params.get("access_code")
-
-    if not slot or not code:
-        raise ValueError("slot/code_slot and code/access_code are required")
-
-    await hass.services.async_call(
-        "zwave_js",
-        "set_lock_usercode",
-        {
-            "entity_id": entity_id,
-            "code_slot": slot,
-            "usercode": str(code),
-        },
-        blocking=True,
-    )
-
-    return {
-        "slot": slot,
-        "verified": False,
-        "method": "zwave_set",
-    }
+    provider = providers.select_provider(hass, entity_id)
+    result = await provider.set_code(hass, entity_id, slot, str(code))
+    return _provider_result_to_dict(result)
 
 
 async def handle_clear_access_code(
@@ -107,28 +88,61 @@ async def handle_clear_access_code(
     device_map: DeviceMap,
     params: Dict[str, Any],
 ) -> Dict[str, Any]:
-    """Clear an access code from a lock."""
+    """Clear an access code from a lock via the protocol-appropriate provider."""
     entity_id = _resolve_entity_id(device_map, params)
+    slot = _resolve_slot(params)
 
-    slot = params.get("slot") or params.get("code_slot")
-    if not slot:
-        raise ValueError("slot/code_slot is required")
+    provider = providers.select_provider(hass, entity_id)
+    result = await provider.clear_code(hass, entity_id, slot)
 
-    await hass.services.async_call(
-        "zwave_js",
-        "clear_lock_usercode",
-        {
-            "entity_id": entity_id,
-            "code_slot": slot,
-        },
-        blocking=True,
-    )
+    out = _provider_result_to_dict(result)
+    out["cleared"] = result.error is None
+    return out
 
-    return {"slot": slot, "cleared": True}
+
+async def handle_read_codes(
+    hass: HomeAssistant,
+    device_map: DeviceMap,
+    params: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Read code slot contents from a lock via the protocol-appropriate provider."""
+    entity_id = _resolve_entity_id(device_map, params)
+    max_slots = int(params.get("max_slots", 30))
+
+    provider = providers.select_provider(hass, entity_id)
+    slots = await provider.read_codes(hass, entity_id, max_slots=max_slots)
+    return {"slots": [_slot_info_to_dict(s) for s in slots]}
+
+
+async def handle_lock_capabilities(
+    hass: HomeAssistant,
+    device_map: DeviceMap,
+    params: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Get protocol-aware capability info for a lock entity."""
+    entity_id = _resolve_entity_id(device_map, params)
+    provider = providers.select_provider(hass, entity_id)
+    caps = await provider.get_capabilities(hass, entity_id)
+    return {
+        "protocol": provider.name,
+        "supports_access_codes": caps.supports_access_codes,
+        "max_slots": caps.max_slots,
+        "extra": caps.extra,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _resolve_entity_id(device_map: DeviceMap, params: Dict[str, Any]) -> str:
-    """Resolve HA entity_id from either ``external_id`` or ``device_id``."""
+    """Resolve HA entity_id from either ``external_id`` or ``device_id``.
+
+    Orion sends ``external_id`` (the HA entity_id) for worker-driven
+    actions, while dashboard actions send ``device_id`` (Staykey internal
+    UUID that needs a device_map lookup).  Accept both conventions.
+    """
     external_id = params.get("external_id", "")
     if external_id:
         return external_id
@@ -141,3 +155,38 @@ def _resolve_entity_id(device_map: DeviceMap, params: Dict[str, Any]) -> str:
     raise ValueError(
         f"Cannot resolve entity: device_id={device_id!r}, external_id={external_id!r}"
     )
+
+
+def _resolve_slot(params: Dict[str, Any]) -> int:
+    slot = params.get("slot") or params.get("code_slot")
+    if slot is None:
+        raise ValueError("slot/code_slot is required")
+    return int(slot)
+
+
+def _resolve_slot_and_code(params: Dict[str, Any]) -> tuple[int, str]:
+    code = params.get("code") or params.get("access_code")
+    if not code:
+        raise ValueError("code/access_code is required")
+    return _resolve_slot(params), str(code)
+
+
+def _provider_result_to_dict(result: ProviderResult) -> Dict[str, Any]:
+    out: Dict[str, Any] = {
+        "slot": result.slot,
+        "method": result.method,
+        "verified": result.verified,
+        "attempts": result.attempts,
+    }
+    if result.error:
+        out["error"] = result.error
+    if result.extra:
+        out["extra"] = result.extra
+    return out
+
+
+def _slot_info_to_dict(info: SlotInfo) -> Dict[str, Any]:
+    out: Dict[str, Any] = {"slot": info.slot, "occupied": info.occupied}
+    if info.code is not None:
+        out["code"] = info.code
+    return out

--- a/custom_components/staykey/handlers/passthrough.py
+++ b/custom_components/staykey/handlers/passthrough.py
@@ -1,32 +1,25 @@
-"""Generic HA service-call passthrough.
+"""Generic Home Assistant service-call passthrough.
 
-Lets the gateway (and therefore Orion or a curl-to-``/internal/command``)
-fire arbitrary Home Assistant service calls without going through one of
-the typed Staykey handlers in :mod:`..handlers.lock` /
-:mod:`..handlers.switch` / etc.
+Allows authenticated gateway clients to invoke ``hass.services.async_call``
+without going through the typed handlers in :mod:`..handlers.lock`,
+:mod:`..handlers.switch`, etc.
 
 ## Why this exists
 
-When debugging vendor-specific Matter / Z-Wave quirks (e.g. the Ultraloq
-Bolt SE rejecting ``matter.set_lock_credential`` with an unmapped 0x85
-status), it's enormously faster to iterate against the real lock by
-poking different payload shapes from the dev machine than it is to
-ship a plugin release and wait for HACS / restart.
-
-The passthrough also makes the ``/internal/command`` interface useful
-for Orion-side integration tests against a real HA — ``call_service``
-becomes the primitive, and Staykey-typed actions become higher-level
-conveniences on top of it.
+Useful when debugging vendor-specific Matter or Z-Wave behavior: iterate
+payloads against a real device from a dev machine without shipping a new
+plugin build. Also supports automated tests that need a thin ``call_service``
+primitive.
 
 ## Security model
 
-* The action is gated by the gateway WebSocket auth (``GATEWAY_TOKEN``)
-  that's already required to reach this handler at all.
-* It is NOT exposed via the Staykey REST webhook surface — it's
-  reachable only over the agent gateway connection.
-* It mirrors the privileges of the HA process Staykey is running
-  inside, so it's no more dangerous than HA's own Developer Tools
-  service caller.
+* Only available to callers that have already authenticated to the
+  Staykey gateway (same trust boundary as the rest of the gateway
+  protocol).
+* Not exposed on the public REST webhook action list --- gateway channel
+  only.
+* Privilege level matches whatever Home Assistant already grants the
+  integration user (comparable to Developer Tools » Services).
 """
 
 from __future__ import annotations

--- a/custom_components/staykey/handlers/passthrough.py
+++ b/custom_components/staykey/handlers/passthrough.py
@@ -1,0 +1,161 @@
+"""Generic HA service-call passthrough.
+
+Lets the gateway (and therefore Orion or a curl-to-``/internal/command``)
+fire arbitrary Home Assistant service calls without going through one of
+the typed Staykey handlers in :mod:`..handlers.lock` /
+:mod:`..handlers.switch` / etc.
+
+## Why this exists
+
+When debugging vendor-specific Matter / Z-Wave quirks (e.g. the Ultraloq
+Bolt SE rejecting ``matter.set_lock_credential`` with an unmapped 0x85
+status), it's enormously faster to iterate against the real lock by
+poking different payload shapes from the dev machine than it is to
+ship a plugin release and wait for HACS / restart.
+
+The passthrough also makes the ``/internal/command`` interface useful
+for Orion-side integration tests against a real HA — ``call_service``
+becomes the primitive, and Staykey-typed actions become higher-level
+conveniences on top of it.
+
+## Security model
+
+* The action is gated by the gateway WebSocket auth (``GATEWAY_TOKEN``)
+  that's already required to reach this handler at all.
+* It is NOT exposed via the Staykey REST webhook surface — it's
+  reachable only over the agent gateway connection.
+* It mirrors the privileges of the HA process Staykey is running
+  inside, so it's no more dangerous than HA's own Developer Tools
+  service caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from ..device_map import DeviceMap
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def handle_ha_service_call(
+    hass: HomeAssistant,
+    device_map: DeviceMap,  # noqa: ARG001 - kept for handler signature uniformity
+    params: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Dispatch ``hass.services.async_call`` with the supplied payload.
+
+    Expected ``params`` shape::
+
+        {
+          "domain": "matter",
+          "service": "set_lock_credential",
+          "service_data": { ... },         # what HA service expects
+          "return_response": true|false,    # default true (we always
+                                            # try to capture results)
+          "blocking": true|false            # default true
+        }
+
+    Returns::
+
+        {
+          "domain": "matter",
+          "service": "set_lock_credential",
+          "response": { ... } | null,
+          "service_data": { ... }            # echoed back, useful when
+                                              # the caller batches
+        }
+
+    Raises ``ValueError`` for malformed input and ``HomeAssistantError``
+    propagates verbatim so the caller sees the structured Matter
+    status (translation_placeholders).
+    """
+    domain = params.get("domain")
+    service = params.get("service")
+    service_data = params.get("service_data") or {}
+    return_response = params.get("return_response", True)
+    blocking = params.get("blocking", True)
+
+    if not isinstance(domain, str) or not domain:
+        raise ValueError("ha_service_call: 'domain' is required")
+    if not isinstance(service, str) or not service:
+        raise ValueError("ha_service_call: 'service' is required")
+    if not isinstance(service_data, dict):
+        raise ValueError("ha_service_call: 'service_data' must be an object")
+
+    LOGGER.info(
+        "ha_service_call dispatch domain=%s service=%s "
+        "return_response=%s blocking=%s data_keys=%s",
+        domain,
+        service,
+        return_response,
+        blocking,
+        sorted(service_data.keys()),
+    )
+
+    try:
+        if return_response:
+            response = await hass.services.async_call(
+                domain,
+                service,
+                service_data,
+                blocking=blocking,
+                return_response=True,
+            )
+        else:
+            await hass.services.async_call(
+                domain,
+                service,
+                service_data,
+                blocking=blocking,
+            )
+            response = None
+    except HomeAssistantError as exc:
+        # Surface HA's structured error info (translation_placeholders,
+        # translation_key) back to the caller — that's the whole point
+        # of the passthrough for Matter debugging.
+        placeholders = getattr(exc, "translation_placeholders", None)
+        translation_key = getattr(exc, "translation_key", None)
+        translation_domain = getattr(exc, "translation_domain", None)
+        LOGGER.warning(
+            "ha_service_call failed domain=%s service=%s "
+            "translation_key=%s status=%s exc=%s",
+            domain,
+            service,
+            translation_key,
+            placeholders.get("status") if isinstance(placeholders, dict) else None,
+            exc,
+        )
+        return {
+            "domain": domain,
+            "service": service,
+            "service_data": service_data,
+            "response": None,
+            "error": {
+                "type": type(exc).__name__,
+                "message": str(exc),
+                "translation_domain": translation_domain,
+                "translation_key": translation_key,
+                "translation_placeholders": placeholders
+                if isinstance(placeholders, dict)
+                else None,
+            },
+        }
+
+    LOGGER.info(
+        "ha_service_call ok domain=%s service=%s response_keys=%s",
+        domain,
+        service,
+        sorted(response.keys()) if isinstance(response, dict) else "<no-response>",
+    )
+
+    return {
+        "domain": domain,
+        "service": service,
+        "service_data": service_data,
+        "response": response,
+    }

--- a/custom_components/staykey/lock_capability_heuristics.py
+++ b/custom_components/staykey/lock_capability_heuristics.py
@@ -1,0 +1,36 @@
+"""Pure helpers for inferring lock capabilities from HA entity attributes.
+
+Kept HA-import-free so they're trivially testable without a running
+Home Assistant install.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+def lock_supports_access_codes(
+    attributes: Mapping[str, Any], protocol: Optional[str]
+) -> bool:
+    """Decide whether a lock entity supports access codes.
+
+    The HA ``lock`` ``supported_features`` bit 1 historically indicated
+    access-code capability for Z-Wave but is set independently for Matter
+    (it tracks unbolt support, not credential management).  So we branch:
+
+    * Z-Wave: trust the existing ``supported_features & 1`` heuristic.
+    * Matter: the HA 2026.4 Matter integration registers per-entity
+      services for the lock manager (``matter.set_lock_credential``
+      etc.) on every Matter lock; if the entity is on the Matter
+      integration, advertise access-code support.  Locks that don't
+      actually support credentials will fail the call at runtime, which
+      Orion already handles via ``mark_assignment_skipped``.
+    * Other protocols: keep the legacy heuristic.
+    """
+    if protocol == "matter":
+        return True
+
+    features = attributes.get("supported_features")
+    if isinstance(features, int) and features & 1:
+        return True
+    return False

--- a/custom_components/staykey/lock_capability_heuristics.py
+++ b/custom_components/staykey/lock_capability_heuristics.py
@@ -19,16 +19,41 @@ def lock_supports_access_codes(
     (it tracks unbolt support, not credential management).  So we branch:
 
     * Z-Wave: trust the existing ``supported_features & 1`` heuristic.
-    * Matter: the HA 2026.4 Matter integration registers per-entity
-      services for the lock manager (``matter.set_lock_credential``
-      etc.) on every Matter lock; if the entity is on the Matter
-      integration, advertise access-code support.  Locks that don't
-      actually support credentials will fail the call at runtime, which
-      Orion already handles via ``mark_assignment_skipped``.
+    * Matter: prefer concrete signals before falling back to the
+      "registered service" assumption. The Matter integration
+      registers ``matter.set_lock_credential`` on every Matter lock
+      regardless of whether the device actually supports PIN credentials,
+      so the bare presence of the service is a poor signal. Locks that
+      don't support PIN management end up appearing in pickers and
+      failing at programming time — bad UX. Use these signals in order:
+        1. ``supported_credential_types`` includes ``"pin"`` — the
+           Matter ``DoorLock`` cluster reports this when the lock
+           advertises PIN support.
+        2. ``max_pin_users`` / ``max_users`` is a positive int — the
+           lock claims at least one PIN user slot.
+        3. Fallback to ``supports_user_management`` flag if HA exposes it.
+      If none of these are present, return ``False``. Locks the
+      heuristic gets wrong (e.g. report PIN support but reject SetCredential)
+      will still surface as a runtime failure; the host platform can
+      then mark the device as unsuitable and stop scheduling codes for it.
     * Other protocols: keep the legacy heuristic.
     """
     if protocol == "matter":
-        return True
+        supported_types = attributes.get("supported_credential_types")
+        if isinstance(supported_types, (list, tuple)) and any(
+            isinstance(t, str) and t.lower() == "pin" for t in supported_types
+        ):
+            return True
+
+        for key in ("max_pin_users", "max_users"):
+            value = attributes.get(key)
+            if isinstance(value, int) and value > 0:
+                return True
+
+        if attributes.get("supports_user_management") is True:
+            return True
+
+        return False
 
     features = attributes.get("supported_features")
     if isinstance(features, int) and features & 1:

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.4",
+  "version": "1.6.0-beta.5",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.5.0",
+  "version": "1.6.0-beta.1",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -4,9 +4,11 @@
   "version": "1.6.0-beta.12",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
+  "homeassistant": "2026.4.0",
   "requirements": [],
   "after_dependencies": [
-    "zwave_js"
+    "zwave_js",
+    "matter"
   ],
   "codeowners": [
     "@staykey"

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.5",
+  "version": "1.6.0-beta.6",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.9",
+  "version": "1.6.0-beta.10",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0-beta.2",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.8",
+  "version": "1.6.0-beta.9",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.10",
+  "version": "1.6.0-beta.11",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.12",
+  "version": "1.6.0-beta.13",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "homeassistant": "2026.4.0",

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.6",
+  "version": "1.6.0-beta.7",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.3",
+  "version": "1.6.0-beta.4",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.7",
+  "version": "1.6.0-beta.8",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.11",
+  "version": "1.6.0-beta.12",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/manifest.json
+++ b/custom_components/staykey/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "staykey",
   "name": "Staykey",
-  "version": "1.6.0-beta.2",
+  "version": "1.6.0-beta.3",
   "documentation": "https://github.com/staykey/staykey-ha-plugin",
   "issue_tracker": "https://github.com/staykey/staykey-ha-plugin/issues",
   "requirements": [],

--- a/custom_components/staykey/services/ha_bridge.py
+++ b/custom_components/staykey/services/ha_bridge.py
@@ -99,11 +99,10 @@ async def _handle_list_entities(
     hass: HomeAssistant,
     params: Dict[str, Any],
 ) -> list:
-    """List entities in the format expected by Orion's list_ha_entities endpoint.
+    """Flatten discovered devices for list_entities consumers.
 
-    Calls discover_devices internally and reformats the response to the
-    flat array format that Nimbus expects (entity_id, friendly_name, type,
-    etc.).
+    Wraps ``discover_devices`` and returns the flat array of entities the
+    Staykey host API expects (entity id, friendly name, type, etc.).
     """
     result = await device_discovery.handle_discover_devices(hass, params)
     devices = result.get("devices", [])

--- a/custom_components/staykey/services/ha_bridge.py
+++ b/custom_components/staykey/services/ha_bridge.py
@@ -1,6 +1,10 @@
 """Bridge between Staykey command schemas and HA service calls.
 
 Routes incoming commands to the appropriate handler based on action name.
+Access-code commands (``set_lock_access_code`` / ``clear_lock_access_code``
+/ ``get_lock_access_codes``) all go through ``handlers/lock.py``, which
+in turn dispatches to the protocol-specific
+:class:`LockProvider <.lock_provider.LockProvider>`.
 """
 
 from __future__ import annotations
@@ -23,15 +27,18 @@ from ..handlers import (
     switch,
 )
 from ..handlers.utils import ProgressFn
-from ..services import zwave
 
 LOGGER = logging.getLogger(__name__)
 
 _ACTION_MAP = {
     "lock": lock.handle_lock,
     "unlock": lock.handle_unlock,
+    "set_access_code": lock.handle_set_access_code,
+    "set_lock_access_code": lock.handle_set_access_code,
     "clear_access_code": lock.handle_clear_access_code,
     "clear_lock_access_code": lock.handle_clear_access_code,
+    "get_access_codes": lock.handle_read_codes,
+    "get_lock_access_codes": lock.handle_read_codes,
     "get_state": state.handle_get_state,
     "get_capabilities": capability.handle_get_capabilities,
     "get_diagnostics": diagnostics.handle_get_diagnostics,
@@ -72,10 +79,6 @@ def create_command_handler(
                 return await handler(hass, device_map, params, progress_fn=progress_fn)
             return await handler(hass, device_map, params)
 
-        if action in ("set_access_code", "set_lock_access_code"):
-            return await _handle_set_access_code(hass, device_map, params)
-        if action in ("get_access_codes", "get_lock_access_codes"):
-            return await _handle_get_access_codes(hass, device_map, params)
         if action == "discover_devices":
             return await device_discovery.handle_discover_devices(hass, params)
         if action == "list_entities":
@@ -88,75 +91,15 @@ def create_command_handler(
     return handle_command
 
 
-def _resolve_entity_id(
-    device_map: DeviceMap,
-    params: Dict[str, Any],
-) -> str:
-    """Resolve HA entity_id from params.
-
-    Orion sends ``external_id`` (the HA entity_id) for worker-driven
-    actions, while dashboard actions send ``device_id`` (Staykey internal
-    UUID that needs a device_map lookup).  Accept both conventions.
-    """
-    external_id = params.get("external_id", "")
-    if external_id:
-        return external_id
-
-    device_id = params.get("device_id", "")
-    entity_id = device_map.get_entity_id(device_id)
-    if entity_id:
-        return entity_id
-
-    raise ValueError(
-        f"Cannot resolve entity: device_id={device_id!r}, external_id={external_id!r}"
-    )
-
-
-async def _handle_set_access_code(
-    hass: HomeAssistant,
-    device_map: DeviceMap,
-    params: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Set access code with optional verification via Z-Wave readback."""
-    entity_id = _resolve_entity_id(device_map, params)
-
-    slot = params.get("slot") or params.get("code_slot")
-    code = params.get("code") or params.get("access_code")
-    verify = params.get("verify") if "verify" in params else params.get("validate", True)
-
-    if not slot or not code:
-        raise ValueError("slot/code_slot and code/access_code are required")
-
-    if verify:
-        return await zwave.set_and_verify_code(
-            hass, entity_id, slot=slot, code=str(code)
-        )
-
-    normalized = {**params, "device_id": params.get("device_id", ""), "slot": slot, "code": code}
-    return await lock.handle_set_access_code(hass, device_map, normalized)
-
-
-async def _handle_get_access_codes(
-    hass: HomeAssistant,
-    device_map: DeviceMap,
-    params: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Read code slot contents from a lock."""
-    entity_id = _resolve_entity_id(device_map, params)
-
-    max_slots = params.get("max_slots", 30)
-    slots = await zwave.read_code_slots(hass, entity_id, max_slots=max_slots)
-    return {"slots": slots}
-
-
 async def _handle_list_entities(
     hass: HomeAssistant,
     params: Dict[str, Any],
 ) -> list:
-    """List entities in the format expected by the Orion list_ha_entities endpoint.
+    """List entities in the format expected by Orion's list_ha_entities endpoint.
 
-    Calls discover_devices internally and reformats the response to match the
-    flat array format that Nimbus expects (entity_id, friendly_name, type, etc.).
+    Calls discover_devices internally and reformats the response to the
+    flat array format that Nimbus expects (entity_id, friendly_name, type,
+    etc.).
     """
     result = await device_discovery.handle_discover_devices(hass, params)
     devices = result.get("devices", [])

--- a/custom_components/staykey/services/ha_bridge.py
+++ b/custom_components/staykey/services/ha_bridge.py
@@ -23,6 +23,7 @@ from ..handlers import (
     device_discovery,
     diagnostics,
     lock,
+    passthrough,
     state,
     switch,
 )
@@ -49,6 +50,7 @@ _ACTION_MAP = {
     "turn_off": switch.handle_turn_off,
     "set_temperature": climate.handle_set_temperature,
     "set_hvac_mode": climate.handle_set_hvac_mode,
+    "ha_service_call": passthrough.handle_ha_service_call,
 }
 
 _PROGRESS_ACTIONS = {"lock", "unlock", "open_cover", "close_cover"}

--- a/custom_components/staykey/services/ha_bridge.py
+++ b/custom_components/staykey/services/ha_bridge.py
@@ -22,6 +22,7 @@ from ..handlers import (
     cover,
     device_discovery,
     diagnostics,
+    event_tap,
     lock,
     passthrough,
     state,
@@ -51,6 +52,7 @@ _ACTION_MAP = {
     "set_temperature": climate.handle_set_temperature,
     "set_hvac_mode": climate.handle_set_hvac_mode,
     "ha_service_call": passthrough.handle_ha_service_call,
+    "tap_events": event_tap.handle_tap_events,
 }
 
 _PROGRESS_ACTIONS = {"lock", "unlock", "open_cover", "close_cover"}

--- a/custom_components/staykey/services/lock_provider.py
+++ b/custom_components/staykey/services/lock_provider.py
@@ -59,18 +59,10 @@ class CapabilityInfo:
     """Capability summary for a lock entity.
 
     ``max_slots`` is the total number of usable PIN positions (effective
-    code slots).  For Z-Wave this is the lock's user-code count; for
-    Matter it's ``max_users * max_credentials_per_user`` once we
-    user-stack credentials, falling back to ``max_pin_users`` /
-    ``max_users`` when the lock doesn't advertise per-user stacking.
-
-    ``max_users`` and ``max_credentials_per_user`` are Matter-specific
-    capacity hints — Matter §5.2.4.41 lets each lock user hold up to
-    ``NumberOfCredentialsSupportedPerUser`` PIN credentials, which lets
-    low-user-count locks (e.g. Ultraloq Bolt SE: 10 users × 5 PINs = 50
-    effective slots) carry far more codes than their advertised user
-    count would suggest.  Both are ``None`` for protocols that don't
-    expose them.
+    code slots).  For Z-Wave it's the lock's user-code count; for Matter
+    it's ``NumberOfPINUsersSupported`` (the empirical global PIN
+    credential cap, see ``MatterLockProvider`` for why we don't multiply
+    by ``NumberOfCredentialsSupportedPerUser``).
 
     ``extra`` is protocol-specific (e.g. Z-Wave node statistics, Matter
     feature map bits).
@@ -78,8 +70,6 @@ class CapabilityInfo:
 
     supports_access_codes: bool
     max_slots: Optional[int] = None
-    max_users: Optional[int] = None
-    max_credentials_per_user: Optional[int] = None
     extra: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/custom_components/staykey/services/lock_provider.py
+++ b/custom_components/staykey/services/lock_provider.py
@@ -58,12 +58,28 @@ class SlotInfo:
 class CapabilityInfo:
     """Capability summary for a lock entity.
 
+    ``max_slots`` is the total number of usable PIN positions (effective
+    code slots).  For Z-Wave this is the lock's user-code count; for
+    Matter it's ``max_users * max_credentials_per_user`` once we
+    user-stack credentials, falling back to ``max_pin_users`` /
+    ``max_users`` when the lock doesn't advertise per-user stacking.
+
+    ``max_users`` and ``max_credentials_per_user`` are Matter-specific
+    capacity hints — Matter §5.2.4.41 lets each lock user hold up to
+    ``NumberOfCredentialsSupportedPerUser`` PIN credentials, which lets
+    low-user-count locks (e.g. Ultraloq Bolt SE: 10 users × 5 PINs = 50
+    effective slots) carry far more codes than their advertised user
+    count would suggest.  Both are ``None`` for protocols that don't
+    expose them.
+
     ``extra`` is protocol-specific (e.g. Z-Wave node statistics, Matter
     feature map bits).
     """
 
     supports_access_codes: bool
     max_slots: Optional[int] = None
+    max_users: Optional[int] = None
+    max_credentials_per_user: Optional[int] = None
     extra: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/custom_components/staykey/services/lock_provider.py
+++ b/custom_components/staykey/services/lock_provider.py
@@ -1,0 +1,111 @@
+"""Protocol-agnostic lock-provider abstraction.
+
+The plugin used to call ``zwave_js.set_lock_usercode`` directly from
+``handlers/lock.py``.  As Staykey adds Matter support (HA 2026.4 lock
+manager) and potentially other smart-home protocols in the future, the
+handler shouldn't know which underlying HA service to invoke.  Instead
+it asks a :class:`LockProvider` selected from the device's protocol.
+
+Concrete providers live under ``services/providers/`` and all return the
+same :class:`ProviderResult` / :class:`SlotInfo` / :class:`CapabilityInfo`
+shapes so Orion's Elixir per-protocol modules can stay in lockstep with
+the plugin path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    runtime_checkable,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+@dataclass
+class ProviderResult:
+    """Outcome of a set_code / clear_code operation.
+
+    Fields mirror what Orion's per-protocol modules return so the same
+    JSON makes it back to the worker regardless of which HA path was used.
+    """
+
+    slot: int
+    method: str  # e.g. "zwave_set_and_verify", "matter_set_credential"
+    verified: bool
+    attempts: int = 1
+    error: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SlotInfo:
+    """One row in a code-slot listing."""
+
+    slot: int
+    occupied: bool
+    code: Optional[str] = None
+
+
+@dataclass
+class CapabilityInfo:
+    """Capability summary for a lock entity.
+
+    ``extra`` is protocol-specific (e.g. Z-Wave node statistics, Matter
+    feature map bits).
+    """
+
+    supports_access_codes: bool
+    max_slots: Optional[int] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class LockProvider(Protocol):
+    """Per-protocol lock operations.
+
+    All methods take an HA ``entity_id`` (the lock entity) and return the
+    typed result objects defined in this module.
+    """
+
+    name: str
+    """Short identifier, e.g. ``"zwave"`` or ``"matter"``."""
+
+    async def set_code(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        slot: int,
+        code: str,
+    ) -> ProviderResult: ...
+
+    async def clear_code(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        slot: int,
+    ) -> ProviderResult: ...
+
+    async def read_codes(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        max_slots: int = 30,
+    ) -> List[SlotInfo]: ...
+
+    async def get_capabilities(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+    ) -> CapabilityInfo: ...
+
+
+class UnsupportedProtocolError(RuntimeError):
+    """Raised when no provider can be selected for a given entity."""

--- a/custom_components/staykey/services/lock_provider.py
+++ b/custom_components/staykey/services/lock_provider.py
@@ -8,8 +8,8 @@ it asks a :class:`LockProvider` selected from the device's protocol.
 
 Concrete providers live under ``services/providers/`` and all return the
 same :class:`ProviderResult` / :class:`SlotInfo` / :class:`CapabilityInfo`
-shapes so Orion's Elixir per-protocol modules can stay in lockstep with
-the plugin path.
+shapes so the cloud/API side can treat gateway and direct HA responses
+the same way without format forks.
 """
 
 from __future__ import annotations
@@ -33,8 +33,8 @@ if TYPE_CHECKING:
 class ProviderResult:
     """Outcome of a set_code / clear_code operation.
 
-    Fields mirror what Orion's per-protocol modules return so the same
-    JSON makes it back to the worker regardless of which HA path was used.
+    Fields align with the JSON contract expected by Staykey's API layer
+    for lock credential operations.
     """
 
     slot: int

--- a/custom_components/staykey/services/providers/__init__.py
+++ b/custom_components/staykey/services/providers/__init__.py
@@ -1,0 +1,78 @@
+"""Provider selection for the protocol-agnostic LockProvider abstraction.
+
+Inspects the device-registry identifiers behind a HA ``entity_id`` and
+returns the right provider.  Inferring from ``entity_id`` itself is
+unreliable for Matter, which is why we walk entity_registry ->
+device_registry and read ``device.identifiers`` (the same source
+``handlers/device_discovery.py`` ``_infer_protocol`` reads).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from ..lock_provider import LockProvider, UnsupportedProtocolError
+from . import matter as matter_provider
+from . import zwave as zwave_provider
+
+LOGGER = logging.getLogger(__name__)
+
+_ZWAVE = zwave_provider.ZwaveLockProvider()
+_MATTER = matter_provider.MatterLockProvider()
+
+_DOMAIN_TO_PROVIDER = {
+    "zwave_js": _ZWAVE,
+    "matter": _MATTER,
+}
+
+
+def select_provider(hass: HomeAssistant, entity_id: str) -> LockProvider:
+    """Select a :class:`LockProvider` from the device-registry identifiers.
+
+    Raises :class:`UnsupportedProtocolError` if the entity is on an
+    integration we don't have a provider for.
+    """
+    protocol = _infer_integration(hass, entity_id)
+    if protocol is None:
+        raise UnsupportedProtocolError(
+            f"Cannot determine integration for entity {entity_id}"
+        )
+
+    provider = _DOMAIN_TO_PROVIDER.get(protocol)
+    if provider is None:
+        raise UnsupportedProtocolError(
+            f"No LockProvider registered for protocol {protocol!r} (entity {entity_id})"
+        )
+
+    LOGGER.debug("Selected %s provider for %s", provider.name, entity_id)
+    return provider
+
+
+def _infer_integration(hass: HomeAssistant, entity_id: str) -> Optional[str]:
+    """Return the leading identifier domain (e.g. 'zwave_js', 'matter')
+    for the device backing *entity_id*, or None if it can't be resolved.
+    """
+    entity_reg = er.async_get(hass)
+    entity_entry = entity_reg.async_get(entity_id)
+    if not entity_entry or not entity_entry.device_id:
+        return None
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get(entity_entry.device_id)
+    if not device or not device.identifiers:
+        return None
+
+    for ident in device.identifiers:
+        parts = list(ident)
+        if parts:
+            domain = str(parts[0]).lower()
+            if domain in _DOMAIN_TO_PROVIDER:
+                return domain
+    return None
+
+
+__all__ = ["select_provider"]

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -4,72 +4,82 @@ Built on the new ``matter.set_lock_credential`` /
 ``matter.clear_lock_user`` / ``matter.get_lock_credential_status``
 service actions added in Home Assistant 2026.4.
 
-Why ``user_index = code_slot``: the Matter ``DoorLock`` cluster's
-``SetCredential`` command lets the caller assign the ``userIndex``
-(range 1-65534).  By making it equal to the Staykey code_slot we avoid
-maintaining a separate ``slot -> matter_user_id`` mapping store, so
-Orion's direct path and the plugin's gateway path stay perfectly
-consistent without reconciliation.
+The Staykey ``slot`` is used as ``credential_index`` only.  Earlier
+versions of this provider tried to use ``slot`` as ``user_index`` too,
+which simplified bookkeeping but assumed every Matter lock implements
+the spec's "auto-create-user-at-the-given-userIndex" path.  Real-world
+testing showed that the **Ultraloq Bolt SE** (and likely other
+vendor-SDK locks) only auto-creates a user when ``userIndex`` is
+**null**, not when ``userIndex`` is non-null and refers to an empty
+user slot — even though the Matter spec describes both paths.
 
-## Why we don't call ``matter.set_lock_user``
+We therefore mirror the flow the official HA Matter Lock Manager UI
+(`frontend#28672 <https://github.com/home-assistant/frontend/pull/28672>`_)
+uses, which is known to work on Aqara U200/U300, Yale Assure 2,
+Schlage Sense Pro, Z-Wave-via-Matter bridges, and the Bolt SE.
 
-HA's ``matter.set_lock_user`` helper is structurally hostile to
-slot-based callers:
+## Two-path SetCredential by slot occupancy
 
-* If you pass ``user_index=N``, HA does ``GetUser(N)`` first.  If the
-  slot is empty it raises ``UserSlotEmptyError("User slot N is empty")``
-  (intended to prevent accidentally Adding when you meant to Modify).
-* The "auto-allocate empty slot then Add" branch only runs when
-  ``user_index=None``, which would force us to give up the
-  ``slot == user_index`` invariant.
+We always pre-flight the slot with ``matter.get_lock_credential_status``
+to learn (a) whether HA will pick ``kAdd`` or ``kModify`` and (b) the
+current user_index for Modify.  Then we send a single
+``matter.set_lock_credential`` shaped for that path:
 
-Per the Matter 1.x spec (DoorLock cluster, SetCredential command), when
-``operationType=kAdd`` and ``userIndex`` references a non-existent
-user, the lock auto-creates that user with default attributes
-(``kOccupiedEnabled`` / ``kUnrestrictedUser`` / ``kSingle``).  HA's
-``set_lock_credential`` helper picks Add vs Modify based on the
-**credential** slot's occupancy, so a single ``set_lock_credential``
-call with ``user_index=slot`` covers both the "new user + new
-credential" and "update existing credential" cases for arbitrary
-caller-supplied slot numbers.
+================  ===============  ==========  ==========  =========================
+Slot state        operation        user_index  user_type   user_status
+================  ===============  ==========  ==========  =========================
+Empty (Add)       HA picks kAdd    *null*      ``unrestricted_user``  *null*
+Occupied (Modify) HA picks kModify existing N  *null*      *null*
+================  ===============  ==========  ==========  =========================
 
-## SetCredential parameter rules (and the 0x85 trap)
+Both shapes are spec-compliant per Matter 1.x §5.2.4.40 and the
+connectedhomeip validity check (``DoorLockServer::SetCredential``,
+chip ``16657402aa``):
 
-Matter spec ``5.2.4.40`` and connectedhomeip's validity check
-(``DoorLockServer::SetCredential``, chip commit ``16657402aa``) require:
+* **Add + userIndex null** → ``userStatus`` and ``userType`` describe
+  the user the lock will auto-create.  Sending ``user_type =
+  unrestricted_user`` here is exactly what the HA Matter Lock Manager
+  frontend does (and what works on the Bolt SE).
+* **Modify + userIndex non-null** → ``userStatus`` and ``userType``
+  MUST both be null; the lock keeps the existing user attributes and
+  only swaps the PIN bytes.
 
-* ``OperationType=Add`` with ``userIndex`` non-null
-  → ``userStatus`` and ``userType`` **MUST both be null**.
-* ``OperationType=Modify`` with ``userIndex`` non-null
-  → ``userStatus`` and ``userType`` **MUST both be null**.
+The combination "Add + userIndex non-null" (which earlier revisions
+of this provider used) is *spec-legal* but only viable on locks that
+implement the auto-create-on-known-index branch.  The Bolt SE doesn't,
+and rejects with ``DlStatus::kInvalidField`` → IM
+``Status::InvalidCommand`` (``0x85`` = ``133``); HA renders that as
+``unknown(133)`` because ``SET_CREDENTIAL_STATUS_MAP`` only knows the
+four lock-level DlStatus values.  This module's prior commit history
+(``b46fbe6``, the spec-compliant rollback that followed) walks through
+both dead-end shapes for posterity.
 
-If either field is non-null the Matter SDK rejects the command with
-``DlStatus::kInvalidField``, which surfaces over the Interaction Model
-as ``Status::InvalidCommand`` (``0x85`` = ``133``).  HA's
-``SET_CREDENTIAL_STATUS_MAP`` only maps the four lock-level DlStatus
-values (success / failure / duplicate / occupied), so 0x85 renders as
-``unknown(133)``.
+## Why we don't call ``matter.set_lock_user`` proactively
 
-We therefore send **only** ``credential_type``, ``credential_data``,
-``credential_index``, and ``user_index`` to ``set_lock_credential``.
-The lock auto-creates the user with ``kUnrestrictedUser`` /
-``kOccupiedEnabled`` defaults on Add — exactly what we want.  This
-matches the spec for the entire compliant lock fleet (Aqara U200/U300,
-Schlage Sense Pro, Yale Assure 2, Z-Wave locks bridged via Matter, and
-the Ultraloq Bolt SE / Bolt Fingerprint).
+We considered a two-step "create user, then attach credential" flow
+(``set_lock_user`` first, then ``set_lock_credential``) but the
+SetCredential auto-create path is simpler, atomic on the lock side,
+and matches the HA UI byte-for-byte.  ``set_lock_user`` is still used
+indirectly via ``clear_lock_user`` on the clear path because that's
+the one Matter command that wipes a user and all their credentials in
+one shot.
 
-> Earlier revisions of this provider sent ``user_type=unrestricted_user``
-> believing the Bolt SE required it explicitly; that turned out to be
-> the cause of the 0x85 rejection rather than the cure (the SDK
-> validity check fires before the lock vendor logic gets to look at
-> the command).
+## Slot ↔ user_index mapping (relinquished)
+
+Earlier docstrings claimed ``slot == user_index`` to avoid a
+mapping-table headache.  That invariant is **no longer maintained**:
+the lock allocates ``user_index`` on Add, we read it back from the
+SetCredential response, and we surface it in ``ProviderResult.extra``
+for callers that want to remember it.  Clearing a slot doesn't need
+the cached value — ``clear_code`` just re-queries
+``get_lock_credential_status(slot)`` to find the user.
 
 ## Verification semantics
 
 * ``matter.set_lock_credential`` returns its result synchronously
   (``credential_index``, ``user_index``, ``next_credential_index``) when
-  called with ``return_response=True``.  A successful response means the
-  Matter server programmed the credential on the lock.
+  called with ``return_response=True``.  A successful response means
+  the Matter server programmed the credential on the lock.
 * If the call raises with a HA-translated status of ``duplicate``, the
   same credential bytes are already programmed in that slot — treated
   as a verified no-op (important for Oban retries that succeeded
@@ -87,7 +97,8 @@ the Ultraloq Bolt SE / Bolt Fingerprint).
 
 Every ``set_code`` / ``clear_code`` attempt emits a single
 ``INFO``-level structured log line on completion with: ``entity_id``,
-``slot``, ``method``, ``verified``, ``matter_status``,
+``slot``, ``operation`` (``add`` or ``modify``), ``method``,
+``verified``, ``matter_status``, ``user_index`` (if known),
 ``duration_ms``, and ``error`` (if any).  The PIN bytes are never
 logged; only ``code_length`` is included so you can correlate length-
 related rejections without leaking secrets.
@@ -111,6 +122,10 @@ LOGGER = logging.getLogger(__name__)
 _MATTER_DOMAIN = "matter"
 _PIN = "pin"
 
+# Matches HA's ``USER_TYPE_MAP`` enum — sent on the wire for the Add
+# path so the lock auto-creates a non-restricted (always-valid) user.
+_USER_TYPE_DEFAULT = "unrestricted_user"
+
 # DoorLock SetCredential status codes that are non-fatal for our use
 # case.  Mapped from chip.clusters.DoorLock.Enums.DlStatus by HA in
 # homeassistant/components/matter/lock_helpers.py:SET_CREDENTIAL_STATUS_MAP.
@@ -131,40 +146,62 @@ class MatterLockProvider:
     ) -> ProviderResult:
         """Set a PIN credential for *slot*, auto-creating the user if needed.
 
-        Single ``matter.set_lock_credential`` call:
+        Two-path single ``matter.set_lock_credential`` call, branched on
+        the slot's current occupancy as observed via
+        ``matter.get_lock_credential_status``:
 
-        * If ``credential_index=slot`` is empty, HA sends ``kAdd``; the
-          Matter spec auto-creates user ``slot`` with default attributes
-          (``kOccupiedEnabled`` / ``kUnrestrictedUser`` / ``kSingle``)
-          and attaches the PIN to it.
-        * If the slot already holds a credential, HA sends ``kModify``
-          to update the PIN bytes.
-        * If the new PIN bytes match what's already there, the lock
-          returns ``duplicate`` status — we treat that as success.
+        * **Empty slot (Add path)** — send ``credential_index=slot``,
+          ``user_index=null``, ``user_type=unrestricted_user``,
+          ``user_status=null``.  HA's helper sees the empty slot and
+          dispatches ``SetCredential(kAdd)``; the lock allocates a
+          fresh user with the supplied user_type and attaches the PIN
+          at our ``credential_index``.
+        * **Occupied slot (Modify path)** — send
+          ``credential_index=slot``,
+          ``user_index=<existing user from GetCredentialStatus>``, both
+          ``user_status`` and ``user_type`` null.  HA dispatches
+          ``SetCredential(kModify)`` and the lock updates the PIN
+          bytes for the existing user.
 
-        We deliberately send neither ``user_status`` nor ``user_type``:
-        per Matter spec ``5.2.4.40`` (and the chip SDK validity check)
-        both fields MUST be null when ``userIndex`` is non-null on Add
-        or Modify.  See module docstring for the full rationale.
+        If the lock returns ``duplicate`` (same PIN bytes already
+        programmed), we treat that as a verified no-op so Oban retries
+        of an op that succeeded silently the first time still
+        converge.
 
-        Falls back to ``matter.get_lock_credential_status`` only if the
-        set call returns without a usable ``credential_index`` and
-        didn't raise.
+        See the module docstring for why this two-path shape is
+        necessary (Bolt SE rejects ``kAdd`` with non-null userIndex
+        despite the spec).
         """
         started_at = time.monotonic()
+
+        existing = await _get_credential_status(hass, entity_id, slot)
+        is_modify = bool(existing and existing.get("credential_exists"))
+        operation = "modify" if is_modify else "add"
+
         request_payload: Dict[str, Any] = {
             "entity_id": entity_id,
             "credential_type": _PIN,
             "credential_data": str(code),
             "credential_index": slot,
-            "user_index": slot,
         }
+        if is_modify:
+            existing_user_index = existing.get("user_index") if existing else None
+            if existing_user_index is not None:
+                request_payload["user_index"] = existing_user_index
+            # No user_type / user_status: must both be null on Modify
+            # when userIndex is non-null (chip SDK validity check).
+        else:
+            # No user_index → null on the wire → lock auto-allocates a
+            # fresh user.  user_type describes that new user.
+            request_payload["user_type"] = _USER_TYPE_DEFAULT
         LOGGER.debug(
             "matter.set_lock_credential request: entity_id=%s slot=%d "
-            "code_length=%d (user_status / user_type omitted per Matter spec)",
+            "operation=%s code_length=%d existing_user_index=%s",
             entity_id,
             slot,
+            operation,
             len(code),
+            request_payload.get("user_index", "<auto>"),
         )
 
         set_response: Optional[Dict[str, Any]] = None
@@ -182,12 +219,15 @@ class MatterLockProvider:
                     slot=slot,
                     method="matter_set_credential_duplicate",
                     verified=True,
-                    extra={"status": _DUPLICATE_STATUS},
+                    extra={
+                        "status": _DUPLICATE_STATUS,
+                        "operation": operation,
+                    },
                 )
-                _log_set_outcome(entity_id, slot, code, started_at, result)
+                _log_set_outcome(entity_id, slot, code, operation, started_at, result)
                 return result
             matter_status = _extract_matter_status(exc)
-            extra: Dict[str, Any] = {}
+            extra: Dict[str, Any] = {"operation": operation}
             if matter_status is not None:
                 extra["matter_status"] = matter_status
             result = ProviderResult(
@@ -197,7 +237,9 @@ class MatterLockProvider:
                 error=_format_set_error(matter_status, exc),
                 extra=extra,
             )
-            _log_set_outcome(entity_id, slot, code, started_at, result, exc=exc)
+            _log_set_outcome(
+                entity_id, slot, code, operation, started_at, result, exc=exc
+            )
             return result
         except Exception as exc:  # pragma: no cover - belt-and-suspenders
             result = ProviderResult(
@@ -205,13 +247,16 @@ class MatterLockProvider:
                 method="matter_set_credential",
                 verified=False,
                 error=f"set_lock_credential: {exc}",
+                extra={"operation": operation},
             )
             LOGGER.exception(
                 "matter.set_lock_credential raised non-HA exception for %s slot %d",
                 entity_id,
                 slot,
             )
-            _log_set_outcome(entity_id, slot, code, started_at, result, exc=exc)
+            _log_set_outcome(
+                entity_id, slot, code, operation, started_at, result, exc=exc
+            )
             return result
 
         per_entity = _extract_entity_response(set_response, entity_id)
@@ -221,12 +266,13 @@ class MatterLockProvider:
                 method="matter_set_credential",
                 verified=True,
                 extra={
+                    "operation": operation,
                     "credential_index": per_entity.get("credential_index"),
                     "user_index": per_entity.get("user_index"),
                     "next_credential_index": per_entity.get("next_credential_index"),
                 },
             )
-            _log_set_outcome(entity_id, slot, code, started_at, result)
+            _log_set_outcome(entity_id, slot, code, operation, started_at, result)
             return result
 
         status = await _get_credential_status(hass, entity_id, slot)
@@ -235,9 +281,12 @@ class MatterLockProvider:
                 slot=slot,
                 method="matter_active_read",
                 verified=True,
-                extra={"user_index": status.get("user_index")},
+                extra={
+                    "operation": operation,
+                    "user_index": status.get("user_index"),
+                },
             )
-            _log_set_outcome(entity_id, slot, code, started_at, result)
+            _log_set_outcome(entity_id, slot, code, operation, started_at, result)
             return result
 
         result = ProviderResult(
@@ -245,8 +294,9 @@ class MatterLockProvider:
             method="matter_set_credential",
             verified=False,
             error="set_lock_credential returned no credential_index and active read did not confirm",
+            extra={"operation": operation},
         )
-        _log_set_outcome(entity_id, slot, code, started_at, result)
+        _log_set_outcome(entity_id, slot, code, operation, started_at, result)
         return result
 
     async def clear_code(
@@ -255,23 +305,61 @@ class MatterLockProvider:
         entity_id: str,
         slot: int,
     ) -> ProviderResult:
-        """Clear by removing the user.
+        """Clear the credential at *slot*.
 
-        Per Matter spec, ClearUser also wipes any associated credentials
-        and schedules in one operation, so we don't need to call
-        ``clear_lock_credential`` separately.
+        Looks up the associated ``user_index`` via
+        ``matter.get_lock_credential_status`` and then issues
+        ``matter.clear_lock_user`` — per Matter spec, ClearUser wipes
+        the user and all of their credentials and schedules atomically,
+        so we don't need a separate ``clear_lock_credential`` call.
+
+        Edge cases:
+
+        * If the credential slot is already empty we return a verified
+          no-op — important for Oban retries.
+        * If the slot has a credential but no associated ``user_index``
+          (orphaned credential, shouldn't happen but defensively
+          handled), we fall back to ``matter.clear_lock_credential``
+          which removes just the credential.
         """
         started_at = time.monotonic()
+
+        existing = await _get_credential_status(hass, entity_id, slot)
+        if existing is None:
+            result = ProviderResult(
+                slot=slot,
+                method="matter_clear_user",
+                verified=False,
+                error="clear_lock_user: get_lock_credential_status returned no data",
+            )
+            _log_clear_outcome(entity_id, slot, started_at, result)
+            return result
+
+        if not existing.get("credential_exists"):
+            result = ProviderResult(
+                slot=slot,
+                method="matter_clear_already_empty",
+                verified=True,
+            )
+            _log_clear_outcome(entity_id, slot, started_at, result)
+            return result
+
+        user_index = existing.get("user_index")
+        if user_index is None:
+            return await self._clear_orphan_credential(
+                hass, entity_id, slot, started_at
+            )
+
         try:
             await hass.services.async_call(
                 _MATTER_DOMAIN,
                 "clear_lock_user",
-                {"entity_id": entity_id, "user_index": slot},
+                {"entity_id": entity_id, "user_index": user_index},
                 blocking=True,
             )
         except HomeAssistantError as exc:
             matter_status = _extract_matter_status(exc)
-            extra: Dict[str, Any] = {}
+            extra: Dict[str, Any] = {"user_index": user_index}
             if matter_status is not None:
                 extra["matter_status"] = matter_status
             result = ProviderResult(
@@ -289,6 +377,7 @@ class MatterLockProvider:
                 method="matter_clear_user",
                 verified=False,
                 error=f"clear_lock_user: {exc}",
+                extra={"user_index": user_index},
             )
             LOGGER.exception(
                 "matter.clear_lock_user raised non-HA exception for %s slot %d",
@@ -298,7 +387,60 @@ class MatterLockProvider:
             _log_clear_outcome(entity_id, slot, started_at, result, exc=exc)
             return result
 
-        result = ProviderResult(slot=slot, method="matter_clear_user", verified=True)
+        result = ProviderResult(
+            slot=slot,
+            method="matter_clear_user",
+            verified=True,
+            extra={"user_index": user_index},
+        )
+        _log_clear_outcome(entity_id, slot, started_at, result)
+        return result
+
+    async def _clear_orphan_credential(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        slot: int,
+        started_at: float,
+    ) -> ProviderResult:
+        """Defensive fallback when a credential exists but has no user.
+
+        Shouldn't happen via our own writes (every ``set_code`` Add
+        path leaves the lock with a fresh user) but guard against
+        out-of-band manipulation.
+        """
+        try:
+            await hass.services.async_call(
+                _MATTER_DOMAIN,
+                "clear_lock_credential",
+                {
+                    "entity_id": entity_id,
+                    "credential_type": _PIN,
+                    "credential_index": slot,
+                },
+                blocking=True,
+            )
+        except HomeAssistantError as exc:
+            matter_status = _extract_matter_status(exc)
+            extra: Dict[str, Any] = {"orphan": True}
+            if matter_status is not None:
+                extra["matter_status"] = matter_status
+            result = ProviderResult(
+                slot=slot,
+                method="matter_clear_credential",
+                verified=False,
+                error=_format_clear_error(matter_status, exc),
+                extra=extra,
+            )
+            _log_clear_outcome(entity_id, slot, started_at, result, exc=exc)
+            return result
+
+        result = ProviderResult(
+            slot=slot,
+            method="matter_clear_credential",
+            verified=True,
+            extra={"orphan": True},
+        )
         _log_clear_outcome(entity_id, slot, started_at, result)
         return result
 
@@ -424,6 +566,7 @@ def _log_set_outcome(
     entity_id: str,
     slot: int,
     code: str,
+    operation: str,
     started_at: float,
     result: ProviderResult,
     *,
@@ -437,16 +580,20 @@ def _log_set_outcome(
     """
     duration_ms = int((time.monotonic() - started_at) * 1000)
     matter_status = result.extra.get("matter_status") or result.extra.get("status")
+    user_index = result.extra.get("user_index")
     log_fn = LOGGER.info if result.verified else LOGGER.error
     log_fn(
-        "matter set_code outcome entity_id=%s slot=%d code_length=%d "
-        "method=%s verified=%s matter_status=%s duration_ms=%d error=%s",
+        "matter set_code outcome entity_id=%s slot=%d operation=%s "
+        "code_length=%d method=%s verified=%s matter_status=%s "
+        "user_index=%s duration_ms=%d error=%s",
         entity_id,
         slot,
+        operation,
         len(code),
         result.method,
         result.verified,
         matter_status or "-",
+        user_index if user_index is not None else "-",
         duration_ms,
         _format_log_error(result.error, exc),
     )
@@ -463,15 +610,18 @@ def _log_clear_outcome(
     """Emit one structured wide-event log line per ``clear_code`` attempt."""
     duration_ms = int((time.monotonic() - started_at) * 1000)
     matter_status = result.extra.get("matter_status")
+    user_index = result.extra.get("user_index")
     log_fn = LOGGER.info if result.verified else LOGGER.error
     log_fn(
         "matter clear_code outcome entity_id=%s slot=%d "
-        "method=%s verified=%s matter_status=%s duration_ms=%d error=%s",
+        "method=%s verified=%s matter_status=%s user_index=%s "
+        "duration_ms=%d error=%s",
         entity_id,
         slot,
         result.method,
         result.verified,
         matter_status or "-",
+        user_index if user_index is not None else "-",
         duration_ms,
         _format_log_error(result.error, exc),
     )

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -1,29 +1,25 @@
-"""Matter LockProvider (HA 2026.4 Matter Lock Manager).
+"""Matter LockProvider (Home Assistant 2026.4 Matter Lock Manager).
 
-Built on the new ``matter.set_lock_credential`` /
-``matter.clear_lock_user`` / ``matter.get_lock_credential_status``
-service actions added in Home Assistant 2026.4.
+Uses ``matter.set_lock_credential``, ``matter.clear_lock_user``,
+``matter.get_lock_credential_status``, and related services from
+Home Assistant 2026.4+.
 
-The Staykey ``slot`` is used as ``credential_index`` only.  Earlier
-versions of this provider tried to use ``slot`` as ``user_index`` too,
-which simplified bookkeeping but assumed every Matter lock implements
-the spec's "auto-create-user-at-the-given-userIndex" path.  Real-world
-testing showed that the **Ultraloq Bolt SE** (and likely other
-vendor-SDK locks) only auto-creates a user when ``userIndex`` is
-**null**, not when ``userIndex`` is non-null and refers to an empty
-user slot — even though the Matter spec describes both paths.
+## Credential index vs user index
 
-We therefore mirror the flow the official HA Matter Lock Manager UI
-(`frontend#28672 <https://github.com/home-assistant/frontend/pull/28672>`_)
-uses, which is known to work on Aqara U200/U300, Yale Assure 2,
-Schlage Sense Pro, Z-Wave-via-Matter bridges, and the Bolt SE.
+The integration maps each caller ``slot`` to Matter ``credential_index``.
+The lock may choose ``user_index`` on Add; we read it from HA responses.
+Older approaches that forced ``slot == user_index`` fail on several vendor
+implementations that only auto-create users when ``user_index`` is omitted
+(null on the wire), even though the Matter spec also describes an alternate
+path.
 
-## Two-branch SetCredential by slot occupancy
+Payloads follow the same Add/Modify split as Home Assistant's Matter Lock
+Manager UI, which is broadly compatible across Matter locks and bridges.
 
-We pre-flight the slot with ``matter.get_lock_credential_status`` to
-learn (a) whether HA will pick ``kAdd`` or ``kModify`` and (b) the
-current user_index for Modify.  Then we send a single
-``matter.set_lock_credential`` shaped for that branch:
+## Add vs Modify
+
+We preflight with ``get_lock_credential_status`` and send one
+``set_lock_credential``:
 
 ==================================  ================  ==========  =====================  ===========
 Slot state                          operation         user_index  user_type              user_status
@@ -32,102 +28,38 @@ Empty slot                          HA picks kAdd     *null*      ``unrestricted
 Occupied slot                       HA picks kModify  existing N  *null*                 *null*
 ==================================  ================  ==========  =====================  ===========
 
-We considered user-stacking (multiple PIN credentials sharing one
-``user_index``) per Matter §5.2.4.41 — the Bolt SE advertises 5 PINs
-per user, which would have notionally given us 50 effective slots.
-Empirically the Bolt SE caps total PIN credentials globally at
-``max_pin_users`` regardless of distribution, so stacking provided no
-capacity benefit; HA's matter integration also doesn't currently
-surface ``user_index`` on ``LockOperation`` events, so the
-recipient-resolution argument disappears too.  We removed the
-sibling-slot probe; if a future use case revives stacking, the probe
-logic is in this module's git history (commits ``b2f1c…`` and
-``397f13e``).
+We do not stack multiple PIN credentials on one ``user_index``: many locks
+cap total PIN credentials at ``max_pin_users``, and the integration does
+not yet expose rich enough lock-bus events for multi-credential user rows
+to be auditable.
 
-Both shapes are spec-compliant per Matter 1.x §5.2.4.40 and the
-connectedhomeip validity check (``DoorLockServer::SetCredential``,
-chip ``16657402aa``):
+On Add we send ``user_type`` and omit ``user_status`` (null on wire). Some
+vendor firmware misbehaves if ``user_status`` is set on Add (SetCredential
+may succeed while the keypad rejects every PIN).
 
-* **Add + userIndex null** → ``userType`` describes the user the lock
-  will auto-create; ``userStatus`` is omitted (null on the wire).
-  This matches the captured payload of HA's Matter Lock Manager UI
-  byte-for-byte, which is the only payload empirically confirmed to
-  produce a working PIN on the Ultraloq Bolt SE.  An earlier revision
-  (plugin v1.6.0-beta.9) sent ``user_status = occupied_enabled`` here
-  on the theory that an explicit-enable would help, but the Bolt SE
-  reacted by writing the credential and leaving the user in a state
-  where the keypad refused every PIN, even though SetCredential
-  returned ``kSuccess``.  Reverting to "user_status omitted" restored
-  parity with the UI flow.
-* **Modify + userIndex non-null** → ``userStatus`` and ``userType``
-  MUST both be null; the lock keeps the existing user attributes and
-  only swaps the PIN bytes.
+If the lock reports ``duplicate``, the PIN is already present; we treat that
+as success so automated retries converge.
 
-The combination "Add + userIndex non-null" (which earlier revisions
-of this provider used) is *spec-legal* but only viable on locks that
-implement the auto-create-on-known-index branch.  The Bolt SE doesn't,
-and rejects with ``DlStatus::kInvalidField`` → IM
-``Status::InvalidCommand`` (``0x85`` = ``133``); HA renders that as
-``unknown(133)`` because ``SET_CREDENTIAL_STATUS_MAP`` only knows the
-four lock-level DlStatus values.  This module's prior commit history
-(``b46fbe6``, the spec-compliant rollback that followed) walks through
-both dead-end shapes for posterity.
+## Clear path
 
-## Why we don't call ``matter.set_lock_user`` proactively
+We look up ``user_index`` when available and prefer ``clear_lock_user`` so
+the user and attached credentials are removed atomically per the Matter
+spec.
 
-We considered a two-step "create user, then attach credential" flow
-(``set_lock_user`` first, then ``set_lock_credential``) but the
-SetCredential auto-create path is simpler, atomic on the lock side,
-and matches the HA UI byte-for-byte.  ``set_lock_user`` is still used
-indirectly via ``clear_lock_user`` on the clear path because that's
-the one Matter command that wipes a user and all their credentials in
-one shot.
+## Concurrency and logging
 
-## Slot ↔ user_index mapping (relinquished)
-
-Earlier docstrings claimed ``slot == user_index`` to avoid a
-mapping-table headache.  That invariant is **no longer maintained**:
-the lock allocates ``user_index`` on Add, we read it back from the
-SetCredential response, and we surface it in ``ProviderResult.extra``
-for callers that want to remember it.  Clearing a slot doesn't need
-the cached value — ``clear_code`` just re-queries
-``get_lock_credential_status(slot)`` to find the user.
-
-## Verification semantics
-
-* ``matter.set_lock_credential`` returns its result synchronously
-  (``credential_index``, ``user_index``, ``next_credential_index``) when
-  called with ``return_response=True``.  A successful response means
-  the Matter server programmed the credential on the lock.
-* If the call raises with a HA-translated status of ``duplicate``, the
-  same credential bytes are already programmed in that slot — treated
-  as a verified no-op (important for Oban retries that succeeded
-  silently the first time).
-* On any other rejection we extract the structured Matter status from
-  the exception's ``translation_placeholders`` and surface it both in
-  logs and in ``ProviderResult.extra["matter_status"]`` /
-  ``ProviderResult.error`` so Orion's activity log shows the actual
-  Matter status code rather than just "set_lock_credential failed".
-* As a defensive sanity check we fall back to
-  ``matter.get_lock_credential_status`` when the set call returns
-  without a usable ``credential_index`` for any other reason.
-
-## Wide-event logging
-
-Every ``set_code`` / ``clear_code`` attempt emits a single
-``INFO``-level structured log line on completion with: ``entity_id``,
-``slot``, ``operation`` (``add`` or ``modify``), ``method``,
-``verified``, ``matter_status``, ``user_index`` (if known),
-``duration_ms``, and ``error`` (if any).  The PIN bytes are never
-logged; only ``code_length`` is included so you can correlate length-
-related rejections without leaking secrets.
+``set_code`` / ``clear_code`` for the same ``entity_id`` are serialized with
+an asyncio lock to prevent read/modify races. Structured logs record
+``code_length`` but never the PIN itself.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from weakref import WeakValueDictionary
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -138,6 +70,24 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
+# Per-entity asyncio.Lock to serialize Matter set/clear/read operations
+# on a single physical lock. Without this, two operations on the same
+# entity (e.g. overlapping set and clear jobs) can race their preflight
+# race their preflight reads against the other's writes (TOCTOU): the
+# preflight sees the slot as empty, takes the Add path, but by the time
+# the SetCredential lands the other op has already added a credential
+# at that index. Using a WeakValueDictionary so locks are GC'd when
+# entities are removed.
+_ENTITY_LOCKS: "WeakValueDictionary[str, asyncio.Lock]" = WeakValueDictionary()
+
+
+def _get_entity_lock(entity_id: str) -> asyncio.Lock:
+    lock = _ENTITY_LOCKS.get(entity_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _ENTITY_LOCKS[entity_id] = lock
+    return lock
+
 _MATTER_DOMAIN = "matter"
 _PIN = "pin"
 
@@ -145,14 +95,10 @@ _PIN = "pin"
 # path so the lock auto-creates a non-restricted (always-valid) user.
 #
 # We deliberately do **not** send ``user_status`` alongside it: the HA
-# Matter Lock Manager UI omits it (verified empirically against the
-# Ultraloq Bolt SE via tap_events capture), and the matter-server SDK
-# defaults ``userStatus`` to its own working value when the field is
-# null on the wire.  Sending ``user_status=occupied_enabled`` —
-# attempted in plugin v1.6.0-beta.9 — caused the Bolt SE to write the
-# credential but leave the user in a state where the keypad refused
-# every PIN, even though SetCredential reported ``kSuccess``.  Removing
-# user_status restored parity with the UI flow.
+# Matter Lock Manager UI omits it on Add, and sending ``occupied_enabled``
+# here has been observed on some firmware to leave the credential written
+# but the keypad rejecting PINs even when SetCredential returns success.
+# Omitting ``user_status`` matches that UI behavior.
 _USER_TYPE_DEFAULT = "unrestricted_user"
 
 # DoorLock SetCredential status codes that are non-fatal for our use
@@ -163,9 +109,8 @@ _DUPLICATE_STATUS = "duplicate"
 # Matter IM-level ``Status::InvalidCommand`` rendered through HA's
 # ``unknown(<int>)`` fallback when the status didn't match
 # ``SET_CREDENTIAL_STATUS_MAP``.  In practice this is what real-world
-# locks return when ``credential_index`` is out of range
-# (``credential_index > NumberOfPINCredentialsSupported``) — see the
-# Ultraloq Bolt SE which advertises 10 PIN slots and rejects index 11+.
+# locks return when ``credential_index`` exceeds hardware limits — e.g.
+# requesting slot 11 on a lock that only allows 10 PIN credentials.
 _UNKNOWN_INVALID_FIELD_STATUS = "unknown(133)"
 
 
@@ -175,6 +120,16 @@ class MatterLockProvider:
     name: str = "matter"
 
     async def set_code(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        slot: int,
+        code: str,
+    ) -> ProviderResult:
+        async with _get_entity_lock(entity_id):
+            return await self._set_code_locked(hass, entity_id, slot, code)
+
+    async def _set_code_locked(
         self,
         hass: HomeAssistant,
         entity_id: str,
@@ -198,35 +153,46 @@ class MatterLockProvider:
           ``user_type=unrestricted_user``, ``user_status=null``.  HA
           dispatches ``SetCredential(kAdd)``; the lock auto-allocates a
           fresh user with the supplied user_type and attaches the PIN
-          at our ``credential_index``.  Each Staykey-managed credential
-          gets its own auto-allocated user — we don't try to stack
-          multiple credentials onto a single ``user_index``.
+          at our ``credential_index``.  Each caller slot gets its own
+          auto-allocated user — we don't stack multiple credentials onto a
+          single ``user_index``.
 
-        We considered user-stacking (multiple PIN credentials sharing
-        one ``user_index``) per Matter §5.2.4.41 — on the Ultraloq
-        Bolt SE that allows up to 5 PINs per user.  In practice it
-        provided no capacity benefit (the Bolt SE caps total PIN
-        credentials globally at ``max_pin_users``, regardless of
-        distribution) and HA's matter integration doesn't currently
-        surface ``user_index`` on ``LockOperation`` events anyway, so
-        the recipient-resolution argument disappears.  Keeping each
-        credential under its own user keeps the data model simple and
-        unambiguous; if a future use case revives stacking, the probe
-        logic is in this module's git history (commits ``b2f1c…`` and
-        ``397f13e``).
+        Stacking multiple PINs on one ``user_index`` (per Matter §5.2.4.41)
+        often yields no real capacity gain because firmware frequently caps
+        total PIN credentials at ``max_pin_users``. Keeping one credential
+        per user keeps behavior predictable.
 
         If the lock returns ``duplicate`` (same PIN bytes already
-        programmed), we treat that as a verified no-op so Oban retries
-        of an op that succeeded silently the first time still
+        programmed), we treat that as a verified no-op so automated retries
         converge.
 
         See the module docstring for why we never send a non-null
-        userIndex pointing at an *empty* user slot (Bolt SE rejects
-        that combination despite the spec describing it).
+        userIndex pointing at an *empty* user slot on locks that only
+        accept Add with a null ``user_index``.
         """
         started_at = time.monotonic()
 
-        existing = await _get_credential_status(hass, entity_id, slot)
+        try:
+            existing = await _get_credential_status(hass, entity_id, slot)
+        except PreflightUnavailable as exc:
+            # Fail safe: we don't know if the slot is occupied. Adding a
+            # PIN to an occupied slot can produce undefined behaviour on
+            # some firmware (silent overwrite, error, or worse). Bail
+            # Return a definitive failure to the caller (upstream marks
+            # this class of error as non-retriable).
+            result = ProviderResult(
+                slot=slot,
+                method="matter_set_credential",
+                verified=False,
+                error=f"set_lock_credential: preflight_unavailable: {exc.original or exc}",
+                extra={
+                    "operation": "preflight",
+                    "preflight_error": str(exc.original or exc),
+                },
+            )
+            _log_set_outcome(entity_id, slot, code, "preflight", started_at, result, exc=exc.original)
+            return result
+
         is_modify = bool(existing and existing.get("credential_exists"))
         operation = "modify" if is_modify else "add"
 
@@ -244,10 +210,10 @@ class MatterLockProvider:
             # when userIndex is non-null (chip SDK validity check).
         else:
             # No user_index → null on the wire → lock auto-allocates a
-            # fresh user.  ``user_type`` describes the auto-created
-            # user; ``user_status`` is intentionally omitted (see the
-            # ``_USER_TYPE_DEFAULT`` constant for why — sending it
-            # actively breaks the Bolt SE).
+            # fresh user. ``user_type`` describes the auto-created user.
+            # ``user_status`` is intentionally omitted — see
+            # ``_USER_TYPE_DEFAULT`` (some locks reject keypad entry if
+            # ``user_status`` is set on Add).
             request_payload["user_type"] = _USER_TYPE_DEFAULT
         LOGGER.debug(
             "matter.set_lock_credential request: entity_id=%s slot=%d "
@@ -335,7 +301,12 @@ class MatterLockProvider:
             _log_set_outcome(entity_id, slot, code, operation, started_at, result)
             return result
 
-        status = await _get_credential_status(hass, entity_id, slot)
+        try:
+            status = await _get_credential_status(hass, entity_id, slot)
+        except PreflightUnavailable:
+            # Fall through to "no confirmation" failure path below.
+            status = None
+
         if status and status.get("credential_exists"):
             result = ProviderResult(
                 slot=slot,
@@ -365,6 +336,15 @@ class MatterLockProvider:
         entity_id: str,
         slot: int,
     ) -> ProviderResult:
+        async with _get_entity_lock(entity_id):
+            return await self._clear_code_locked(hass, entity_id, slot)
+
+    async def _clear_code_locked(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        slot: int,
+    ) -> ProviderResult:
         """Clear the credential at *slot*.
 
         Looks up the associated ``user_index`` via
@@ -376,7 +356,7 @@ class MatterLockProvider:
         Edge cases:
 
         * If the credential slot is already empty we return a verified
-          no-op — important for Oban retries.
+          no-op — important when automation retries an already-applied clear.
         * If the slot has a credential but no associated ``user_index``
           (orphaned credential, shouldn't happen but defensively
           handled), we fall back to ``matter.clear_lock_credential``
@@ -384,13 +364,27 @@ class MatterLockProvider:
         """
         started_at = time.monotonic()
 
-        existing = await _get_credential_status(hass, entity_id, slot)
-        if existing is None:
+        try:
+            existing = await _get_credential_status(hass, entity_id, slot)
+        except PreflightUnavailable as exc:
             result = ProviderResult(
                 slot=slot,
                 method="matter_clear_user",
                 verified=False,
-                error="clear_lock_user: get_lock_credential_status returned no data",
+                error=f"clear_lock_user: preflight_unavailable: {exc.original or exc}",
+                extra={"preflight_error": str(exc.original or exc)},
+            )
+            _log_clear_outcome(entity_id, slot, started_at, result, exc=exc.original)
+            return result
+
+        if existing is None:
+            # HA responded but didn't include data for this entity/slot.
+            # Treat as "no credential to clear" (verified no-op) so retries
+            # of an already-satisfied request still converge.
+            result = ProviderResult(
+                slot=slot,
+                method="matter_clear_already_empty",
+                verified=True,
             )
             _log_clear_outcome(entity_id, slot, started_at, result)
             return result
@@ -519,7 +513,12 @@ class MatterLockProvider:
         """
         results: List[SlotInfo] = []
         for slot in range(1, max_slots + 1):
-            status = await _get_credential_status(hass, entity_id, slot)
+            try:
+                status = await _get_credential_status(hass, entity_id, slot)
+            except PreflightUnavailable:
+                # Skip the slot rather than misreporting it as empty.
+                # Caller can re-issue the read later.
+                continue
             if status is None:
                 continue
             results.append(
@@ -608,10 +607,8 @@ def _format_set_error(
 ) -> str:
     """Build the ProviderResult.error string with the Matter status if present.
 
-    Including the status code in the error string means it propagates
-    through Orion's ``DeviceService.classify_action_body/1`` /
-    ``ActivityService.format_error_reason/1`` chain into the user-facing
-    activity log without any further plumbing.
+    Including the status code gives operators a clearer message in Staykey
+    dashboards and logs without extra parsing steps.
 
     When ``extra`` contains a ``reason`` field (e.g. ``slot_out_of_range``)
     we prepend it to the message — this is how the operator sees
@@ -651,9 +648,8 @@ async def _enrich_with_capacity_context(
     DlStatus, so we have no per-status hint to act on.  Instead we
     do a one-shot ``matter.get_lock_info`` lookup and, if the slot is
     out of range, mark the failure as ``slot_out_of_range`` with the
-    advertised ``max_slots`` so callers (Orion, activity log,
-    operator) see *why* the lock rejected the call rather than
-    ``unknown(133)``.
+    advertised ``max_slots`` so operators and UIs see *why* the lock
+    rejected the call rather than only ``unknown(133)``.
 
     The lookup is best-effort — if the lock can't be queried (unstable
     connection, integration version mismatch) we leave ``extra``
@@ -765,9 +761,33 @@ def _format_log_error(error: Optional[str], exc: Optional[BaseException]) -> str
     return "-"
 
 
+class PreflightUnavailable(Exception):
+    """Raised when a Matter preflight call (status / lock info) fails.
+
+    Distinguishes "we don't know the slot state" from "we know the slot is
+    empty". Callers that branch on slot occupancy (e.g.
+    ``MatterLockProvider.set_code``'s Add-vs-Modify decision) must fail
+    safe rather than treat unknown as empty.
+    """
+
+    def __init__(self, message: str, *, original: Optional[BaseException] = None) -> None:
+        super().__init__(message)
+        self.original = original
+
+
 async def _get_credential_status(
     hass: HomeAssistant, entity_id: str, slot: int
 ) -> Optional[Dict[str, Any]]:
+    """Look up the credential status for *slot*.
+
+    Returns the per-entity status dict on success. May return ``None``
+    when HA responded but didn't include an entity-keyed payload (treat
+    as "definitely empty / no data" — distinct from the unknown case).
+
+    Raises :class:`PreflightUnavailable` when the underlying HA service
+    call fails, so callers can fail safe rather than guess slot
+    occupancy from an error.
+    """
     try:
         response = await hass.services.async_call(
             _MATTER_DOMAIN,
@@ -780,14 +800,18 @@ async def _get_credential_status(
             blocking=True,
             return_response=True,
         )
-    except Exception:
-        LOGGER.debug(
-            "matter.get_lock_credential_status failed for %s slot %d",
+    except Exception as exc:
+        LOGGER.warning(
+            "matter.get_lock_credential_status failed for %s slot %d: %s",
             entity_id,
             slot,
+            exc,
             exc_info=True,
         )
-        return None
+        raise PreflightUnavailable(
+            f"get_lock_credential_status failed for {entity_id} slot {slot}",
+            original=exc,
+        ) from exc
 
     return _extract_entity_response(response, entity_id)
 
@@ -804,7 +828,7 @@ async def _get_lock_info(
             return_response=True,
         )
     except Exception:
-        LOGGER.debug(
+        LOGGER.warning(
             "matter.get_lock_info failed for %s", entity_id, exc_info=True
         )
         return None
@@ -823,13 +847,11 @@ def _extract_max_slots(info: Dict[str, Any]) -> Optional[int]:
 
     The Matter spec (§5.2.4.41) implies a lock that also advertises
     ``NumberOfCredentialsSupportedPerUser = C`` can hold ``U × C`` PIN
-    credentials.  In practice firmware like the Ultraloq Bolt SE enforces
-    a tighter global cap equal to ``U`` even when ``C > 1`` (empirically
-    rejects credential_index 11+ once 10 PIN credentials are programmed,
-    regardless of distribution across users).  We therefore size
-    ``max_slots = max_users`` only; locks that genuinely support the
-    full ``U × C`` cap can override via
-    ``SupportedDevice.default_settings`` in Orion.
+    credentials. In practice, vendor firmware enforces
+    a tighter global cap equal to the user count even when the spec would
+    allow more PIN rows per user. We therefore size ``max_slots`` from
+    ``max_pin_users`` / ``max_users`` conservatively; hosts with unusual
+    hardware can correct capacity in the Staykey device catalog if needed.
     """
     candidates = (
         info.get("max_pin_users"),

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -29,28 +29,29 @@ sibling slots in the same user-group to discover an existing
 user_index.  Then we send a single ``matter.set_lock_credential``
 shaped for that branch:
 
-==================================  ===============  ==========  =====================  ====================
+==================================  ===============  ==========  =====================  ===========
 Slot / user-group state             operation        user_index  user_type              user_status
-==================================  ===============  ==========  =====================  ====================
-Empty slot, group has no siblings   HA picks kAdd    *null*      ``unrestricted_user``  ``occupied_enabled``
+==================================  ===============  ==========  =====================  ===========
+Empty slot, group has no siblings   HA picks kAdd    *null*      ``unrestricted_user``  *null*
 Empty slot, group has a sibling     HA picks kAdd    discovered  *null*                 *null*
 Occupied slot                       HA picks kModify existing N  *null*                 *null*
-==================================  ===============  ==========  =====================  ====================
+==================================  ===============  ==========  =====================  ===========
 
 All three shapes are spec-compliant per Matter 1.x §5.2.4.40 and the
 connectedhomeip validity check (``DoorLockServer::SetCredential``,
 chip ``16657402aa``):
 
-* **Add + userIndex null** → ``userStatus`` and ``userType`` describe
-  the user the lock will auto-create.  We send ``user_type =
-  unrestricted_user`` *and* ``user_status = occupied_enabled`` here to
-  match HA's own ``set_lock_user`` defaults (line 357–364 of
-  ``lock_helpers.py``).  Omitting ``user_status`` lets the underlying
-  SDK pass ``userStatus = null`` to the lock; on the Ultraloq Bolt SE
-  that produces a fully written-but-disabled user, so SetCredential
-  returns ``kSuccess`` (``verified=true`` from our side) but the keypad
-  rejects every PIN.  Passing ``occupied_enabled`` is what the HA Lock
-  Manager UI does and what the Bolt SE actually accepts.
+* **Add + userIndex null** → ``userType`` describes the user the lock
+  will auto-create; ``userStatus`` is omitted (null on the wire).
+  This matches the captured payload of HA's Matter Lock Manager UI
+  byte-for-byte, which is the only payload empirically confirmed to
+  produce a working PIN on the Ultraloq Bolt SE.  An earlier revision
+  (plugin v1.6.0-beta.9) sent ``user_status = occupied_enabled`` here
+  on the theory that an explicit-enable would help, but the Bolt SE
+  reacted by writing the credential and leaving the user in a state
+  where the keypad refused every PIN, even though SetCredential
+  returned ``kSuccess``.  Reverting to "user_status omitted" restored
+  parity with the UI flow.
 * **Modify + userIndex non-null** → ``userStatus`` and ``userType``
   MUST both be null; the lock keeps the existing user attributes and
   only swaps the PIN bytes.
@@ -135,21 +136,17 @@ _PIN = "pin"
 
 # Matches HA's ``USER_TYPE_MAP`` enum — sent on the wire for the Add
 # path so the lock auto-creates a non-restricted (always-valid) user.
+#
+# We deliberately do **not** send ``user_status`` alongside it: the HA
+# Matter Lock Manager UI omits it (verified empirically against the
+# Ultraloq Bolt SE via tap_events capture), and the matter-server SDK
+# defaults ``userStatus`` to its own working value when the field is
+# null on the wire.  Sending ``user_status=occupied_enabled`` —
+# attempted in plugin v1.6.0-beta.9 — caused the Bolt SE to write the
+# credential but leave the user in a state where the keypad refused
+# every PIN, even though SetCredential reported ``kSuccess``.  Removing
+# user_status restored parity with the UI flow.
 _USER_TYPE_DEFAULT = "unrestricted_user"
-
-# Matches HA's ``USER_STATUS_MAP`` enum.  Sent alongside
-# ``_USER_TYPE_DEFAULT`` on the fresh-user Add path so the auto-created
-# user lands in the active state.  ``matter.set_lock_credential`` will
-# pass ``userStatus=null`` to the SDK when this argument is omitted, and
-# at least one real-world lock (Ultraloq Bolt SE) interprets a null
-# userStatus on user creation as "store the credential but leave the
-# user disabled" — the credential then verifies at the protocol level
-# (SetCredential returns kSuccess) but the keypad rejects every PIN.
-# Passing ``occupied_enabled`` mirrors what HA's own set_lock_user
-# defaults to for new-user creation and what the HA Lock Manager UI
-# sends when programming a fresh PIN, both of which are confirmed
-# working on the Bolt SE.
-_USER_STATUS_DEFAULT = "occupied_enabled"
 
 # DoorLock SetCredential status codes that are non-fatal for our use
 # case.  Mapped from chip.clusters.DoorLock.Enums.DlStatus by HA in
@@ -269,16 +266,13 @@ class MatterLockProvider:
             request_payload["user_index"] = stacked_user_index
         else:
             # No user_index → null on the wire → lock auto-allocates a
-            # fresh user.  user_type and user_status describe that new
-            # user.  Both are required: omitting user_status causes
-            # firmware like the Ultraloq Bolt SE to leave the user
-            # disabled (writes accepted at the protocol level but the
-            # PIN is rejected at the keypad — exactly the symptom that
-            # used to bite us before this fix).  This is also the path
-            # for non-stacking locks (1 credential per user) where
+            # fresh user.  ``user_type`` describes the auto-created
+            # user; ``user_status`` is intentionally omitted (see the
+            # ``_USER_TYPE_DEFAULT`` constant for why — sending it
+            # actively breaks the Bolt SE).  This is also the path for
+            # non-stacking locks (1 credential per user) where
             # ``max_credentials_per_user`` is None or 1.
             request_payload["user_type"] = _USER_TYPE_DEFAULT
-            request_payload["user_status"] = _USER_STATUS_DEFAULT
         LOGGER.debug(
             "matter.set_lock_credential request: entity_id=%s slot=%d "
             "operation=%s code_length=%d user_index=%s "

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -131,6 +131,14 @@ _USER_TYPE_DEFAULT = "unrestricted_user"
 # homeassistant/components/matter/lock_helpers.py:SET_CREDENTIAL_STATUS_MAP.
 _DUPLICATE_STATUS = "duplicate"
 
+# Matter IM-level ``Status::InvalidCommand`` rendered through HA's
+# ``unknown(<int>)`` fallback when the status didn't match
+# ``SET_CREDENTIAL_STATUS_MAP``.  In practice this is what real-world
+# locks return when ``credential_index`` is out of range
+# (``credential_index > NumberOfPINCredentialsSupported``) — see the
+# Ultraloq Bolt SE which advertises 10 PIN slots and rejects index 11+.
+_UNKNOWN_INVALID_FIELD_STATUS = "unknown(133)"
+
 
 class MatterLockProvider:
     """LockProvider implementation for HA 2026.4 Matter locks."""
@@ -230,11 +238,16 @@ class MatterLockProvider:
             extra: Dict[str, Any] = {"operation": operation}
             if matter_status is not None:
                 extra["matter_status"] = matter_status
+
+            await _enrich_with_capacity_context(
+                hass, entity_id, slot, matter_status, extra
+            )
+
             result = ProviderResult(
                 slot=slot,
                 method="matter_set_credential",
                 verified=False,
-                error=_format_set_error(matter_status, exc),
+                error=_format_set_error(matter_status, exc, extra),
                 extra=extra,
             )
             _log_set_outcome(
@@ -542,17 +555,84 @@ def _extract_matter_status(exc: BaseException) -> Optional[str]:
     return None
 
 
-def _format_set_error(matter_status: Optional[str], exc: BaseException) -> str:
+def _format_set_error(
+    matter_status: Optional[str],
+    exc: BaseException,
+    extra: Optional[Dict[str, Any]] = None,
+) -> str:
     """Build the ProviderResult.error string with the Matter status if present.
 
     Including the status code in the error string means it propagates
     through Orion's ``DeviceService.classify_action_body/1`` /
     ``ActivityService.format_error_reason/1`` chain into the user-facing
     activity log without any further plumbing.
+
+    When ``extra`` contains a ``reason`` field (e.g. ``slot_out_of_range``)
+    we prepend it to the message — this is how the operator sees
+    "the lock only has 10 PIN slots" instead of the cryptic
+    ``unknown(133)``.
     """
+    reason = extra.get("reason") if extra else None
+    max_slots = extra.get("max_slots") if extra else None
+
+    if reason == "slot_out_of_range" and max_slots is not None:
+        slot = extra.get("slot") if extra else None
+        slot_part = f"slot={slot} " if slot is not None else ""
+        return (
+            "set_lock_credential: slot_out_of_range "
+            f"({slot_part}max_slots={max_slots}, "
+            f"matter_status={matter_status or 'unknown'}): {exc}"
+        )
+
     if matter_status:
         return f"set_lock_credential: matter_status={matter_status}: {exc}"
     return f"set_lock_credential: {exc}"
+
+
+async def _enrich_with_capacity_context(
+    hass: HomeAssistant,
+    entity_id: str,
+    slot: int,
+    matter_status: Optional[str],
+    extra: Dict[str, Any],
+) -> None:
+    """Look up the lock's PIN-slot capacity to classify ``unknown(133)``.
+
+    Real-world locks return Matter IM ``Status::InvalidCommand`` (0x85)
+    via the ``unknown(133)`` fallback when ``credential_index`` exceeds
+    ``NumberOfPINCredentialsSupported``.  HA's
+    :pyfunc:`SET_CREDENTIAL_STATUS_MAP` doesn't translate this to a
+    DlStatus, so we have no per-status hint to act on.  Instead we
+    do a one-shot ``matter.get_lock_info`` lookup and, if the slot is
+    out of range, mark the failure as ``slot_out_of_range`` with the
+    advertised ``max_slots`` so callers (Orion, activity log,
+    operator) see *why* the lock rejected the call rather than
+    ``unknown(133)``.
+
+    The lookup is best-effort — if the lock can't be queried (unstable
+    connection, integration version mismatch) we leave ``extra``
+    untouched and the error falls back to the raw matter_status.
+    """
+    if matter_status != _UNKNOWN_INVALID_FIELD_STATUS:
+        return
+
+    info = await _get_lock_info(hass, entity_id)
+    if not info:
+        return
+
+    max_slots = info.get("max_pin_users") or info.get("max_users")
+    if not isinstance(max_slots, int) or max_slots <= 0:
+        return
+
+    extra["max_slots"] = max_slots
+    extra["slot"] = slot
+    if slot > max_slots:
+        extra["reason"] = "slot_out_of_range"
+    else:
+        # Slot is in range but the lock still rejected with 0x85 —
+        # most likely the user table is full (every PIN user occupied)
+        # or the lock disagrees with its own advertised capacity.
+        extra.setdefault("reason", "lock_rejected")
 
 
 def _format_clear_error(matter_status: Optional[str], exc: BaseException) -> str:
@@ -581,11 +661,13 @@ def _log_set_outcome(
     duration_ms = int((time.monotonic() - started_at) * 1000)
     matter_status = result.extra.get("matter_status") or result.extra.get("status")
     user_index = result.extra.get("user_index")
+    reason = result.extra.get("reason")
+    max_slots = result.extra.get("max_slots")
     log_fn = LOGGER.info if result.verified else LOGGER.error
     log_fn(
         "matter set_code outcome entity_id=%s slot=%d operation=%s "
         "code_length=%d method=%s verified=%s matter_status=%s "
-        "user_index=%s duration_ms=%d error=%s",
+        "user_index=%s reason=%s max_slots=%s duration_ms=%d error=%s",
         entity_id,
         slot,
         operation,
@@ -594,6 +676,8 @@ def _log_set_outcome(
         result.verified,
         matter_status or "-",
         user_index if user_index is not None else "-",
+        reason or "-",
+        max_slots if max_slots is not None else "-",
         duration_ms,
         _format_log_error(result.error, exc),
     )

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -1,0 +1,340 @@
+"""Matter LockProvider (HA 2026.4 Matter Lock Manager).
+
+Built on the new ``matter.set_lock_credential`` /
+``matter.clear_lock_user`` / ``matter.get_lock_credential_status``
+service actions added in Home Assistant 2026.4.
+
+Why ``user_index = code_slot``: the Matter ``DoorLock`` cluster's
+``SetCredential`` command lets the caller assign the ``userIndex``
+(range 1-65534).  By making it equal to the Staykey code_slot we avoid
+maintaining a separate ``slot -> matter_user_id`` mapping store, so
+Orion's direct path and the plugin's gateway path stay perfectly
+consistent without reconciliation.
+
+## Why we don't call ``matter.set_lock_user``
+
+HA's ``matter.set_lock_user`` helper is structurally hostile to
+slot-based callers:
+
+* If you pass ``user_index=N``, HA does ``GetUser(N)`` first.  If the
+  slot is empty it raises ``UserSlotEmptyError("User slot N is empty")``
+  (intended to prevent accidentally Adding when you meant to Modify).
+  If the slot is occupied, HA sends ``SetUser(kModify, ...)`` which
+  some Matter locks (Ultraloq Bolt SE confirmed) reject with
+  ``InvalidCommand (0x85)``.
+* The "auto-allocate empty slot then Add" branch only runs when
+  ``user_index=None``, which would force us to give up the
+  ``slot == user_index`` invariant.
+
+Per the Matter 1.x spec (DoorLock cluster, SetCredential command), when
+``operationType=kAdd`` and ``userIndex`` references a non-existent
+user, the lock auto-creates that user with default attributes.  HA's
+``set_lock_credential`` helper picks Add vs Modify based on the
+**credential** slot's occupancy (no empty-slot guard), so a single
+``set_lock_credential`` call with ``user_index=slot`` covers both the
+"new user + new credential" and "update existing credential" cases for
+arbitrary caller-supplied slot numbers.
+
+## Verification semantics
+
+* ``matter.set_lock_credential`` returns its result synchronously
+  (``credential_index``, ``user_index``, ``next_credential_index``) when
+  called with ``return_response=True``.  A successful response means the
+  Matter server programmed the credential on the lock.
+* If the call raises with a HA-translated status of ``duplicate``, the
+  same credential bytes are already programmed in that slot — treated
+  as a verified no-op (important for Oban retries that succeeded
+  silently the first time).
+* As a defensive sanity check we fall back to
+  ``matter.get_lock_credential_status`` when the set call returns
+  without a usable ``credential_index`` for any other reason.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from homeassistant.exceptions import HomeAssistantError
+
+from ..lock_provider import CapabilityInfo, LockProvider, ProviderResult, SlotInfo
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+LOGGER = logging.getLogger(__name__)
+
+_MATTER_DOMAIN = "matter"
+_PIN = "pin"
+_USER_TYPE_DEFAULT = "unrestricted_user"
+_USER_STATUS_ENABLED = "occupied_enabled"
+
+# DoorLock SetCredential status codes that are non-fatal for our use
+# case.  Mapped from chip.clusters.DoorLock.Enums.DlStatus by HA in
+# homeassistant/components/matter/lock_helpers.py:SET_CREDENTIAL_STATUS_MAP.
+_DUPLICATE_STATUS = "duplicate"
+
+
+class MatterLockProvider:
+    """LockProvider implementation for HA 2026.4 Matter locks."""
+
+    name: str = "matter"
+
+    async def set_code(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        slot: int,
+        code: str,
+    ) -> ProviderResult:
+        """Set a PIN credential for *slot*, auto-creating the user if needed.
+
+        Single ``matter.set_lock_credential`` call:
+
+        * If ``credential_index=slot`` is empty, HA sends ``kAdd``; the
+          Matter spec auto-creates user ``slot`` with default attributes
+          and attaches the PIN to it.
+        * If the slot already holds a credential, HA sends ``kModify``
+          to update the PIN bytes.
+        * If the new PIN bytes match what's already there, the lock
+          returns ``duplicate`` status — we treat that as success.
+
+        Falls back to ``matter.get_lock_credential_status`` only if the
+        set call returns without a usable ``credential_index`` and
+        didn't raise.
+        """
+        set_response: Optional[Dict[str, Any]] = None
+        try:
+            set_response = await hass.services.async_call(
+                _MATTER_DOMAIN,
+                "set_lock_credential",
+                {
+                    "entity_id": entity_id,
+                    "credential_type": _PIN,
+                    "credential_data": str(code),
+                    "credential_index": slot,
+                    "user_index": slot,
+                    "user_status": _USER_STATUS_ENABLED,
+                },
+                blocking=True,
+                return_response=True,
+            )
+        except HomeAssistantError as exc:
+            if _is_duplicate_credential_error(exc):
+                LOGGER.info(
+                    "matter.set_lock_credential reported duplicate for %s slot %d; "
+                    "treating as verified no-op",
+                    entity_id,
+                    slot,
+                )
+                return ProviderResult(
+                    slot=slot,
+                    method="matter_set_credential_duplicate",
+                    verified=True,
+                    extra={"status": _DUPLICATE_STATUS},
+                )
+            LOGGER.exception(
+                "matter.set_lock_credential failed for %s slot %d", entity_id, slot
+            )
+            return ProviderResult(
+                slot=slot,
+                method="matter_set_credential",
+                verified=False,
+                error=f"set_lock_credential: {exc}",
+            )
+        except Exception as exc:
+            LOGGER.exception(
+                "matter.set_lock_credential failed for %s slot %d", entity_id, slot
+            )
+            return ProviderResult(
+                slot=slot,
+                method="matter_set_credential",
+                verified=False,
+                error=f"set_lock_credential: {exc}",
+            )
+
+        per_entity = _extract_entity_response(set_response, entity_id)
+        if per_entity and per_entity.get("credential_index") is not None:
+            return ProviderResult(
+                slot=slot,
+                method="matter_set_credential",
+                verified=True,
+                extra={
+                    "credential_index": per_entity.get("credential_index"),
+                    "user_index": per_entity.get("user_index"),
+                    "next_credential_index": per_entity.get("next_credential_index"),
+                },
+            )
+
+        status = await _get_credential_status(hass, entity_id, slot)
+        if status and status.get("credential_exists"):
+            return ProviderResult(
+                slot=slot,
+                method="matter_active_read",
+                verified=True,
+                extra={"user_index": status.get("user_index")},
+            )
+
+        return ProviderResult(
+            slot=slot,
+            method="matter_set_credential",
+            verified=False,
+            error="set_lock_credential returned no credential_index and active read did not confirm",
+        )
+
+    async def clear_code(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        slot: int,
+    ) -> ProviderResult:
+        """Clear by removing the user.
+
+        Per Matter spec, ClearUser also wipes any associated credentials
+        and schedules in one operation, so we don't need to call
+        ``clear_lock_credential`` separately.
+        """
+        try:
+            await hass.services.async_call(
+                _MATTER_DOMAIN,
+                "clear_lock_user",
+                {"entity_id": entity_id, "user_index": slot},
+                blocking=True,
+            )
+        except Exception as exc:
+            LOGGER.exception(
+                "matter.clear_lock_user failed for %s slot %d", entity_id, slot
+            )
+            return ProviderResult(
+                slot=slot,
+                method="matter_clear_user",
+                verified=False,
+                error=f"clear_lock_user: {exc}",
+            )
+
+        return ProviderResult(slot=slot, method="matter_clear_user", verified=True)
+
+    async def read_codes(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        max_slots: int = 30,
+    ) -> List[SlotInfo]:
+        """Probe each slot via ``matter.get_lock_credential_status``.
+
+        Matter doesn't return PIN values (write-only on the lock), so the
+        ``code`` field in the result is always None — only occupancy is
+        observable.  This is intentional: callers that need to display
+        codes should keep them in their own datastore.
+        """
+        results: List[SlotInfo] = []
+        for slot in range(1, max_slots + 1):
+            status = await _get_credential_status(hass, entity_id, slot)
+            if status is None:
+                continue
+            results.append(
+                SlotInfo(
+                    slot=slot,
+                    occupied=bool(status.get("credential_exists")),
+                    code=None,
+                )
+            )
+        return results
+
+    async def get_capabilities(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+    ) -> CapabilityInfo:
+        info = await _get_lock_info(hass, entity_id)
+        if not info:
+            return CapabilityInfo(supports_access_codes=False)
+
+        supports = (
+            bool(info.get("supports_user_management"))
+            and _PIN in (info.get("supported_credential_types") or [])
+        )
+        max_slots = info.get("max_pin_users") or info.get("max_users")
+        return CapabilityInfo(
+            supports_access_codes=supports,
+            max_slots=max_slots,
+            extra=info,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _extract_entity_response(
+    response: Optional[Dict[str, Any]], entity_id: str
+) -> Optional[Dict[str, Any]]:
+    """HA's call_service with return_response wraps results by entity_id."""
+    if not isinstance(response, dict):
+        return None
+    if entity_id in response and isinstance(response[entity_id], dict):
+        return response[entity_id]
+    return response
+
+
+def _is_duplicate_credential_error(exc: BaseException) -> bool:
+    """Detect HA's ``SetCredentialFailedError`` with status=duplicate.
+
+    The matter integration raises ``HomeAssistantError`` subclasses with
+    ``translation_placeholders={"status": "<dl_status>"}``.  The
+    structured field is the most reliable signal; we also fall back to
+    a substring match on the rendered string for safety in case the
+    helper class shape changes between HA releases.
+    """
+    placeholders = getattr(exc, "translation_placeholders", None)
+    if isinstance(placeholders, dict) and placeholders.get("status") == _DUPLICATE_STATUS:
+        return True
+
+    return _DUPLICATE_STATUS in str(exc).lower()
+
+
+async def _get_credential_status(
+    hass: HomeAssistant, entity_id: str, slot: int
+) -> Optional[Dict[str, Any]]:
+    try:
+        response = await hass.services.async_call(
+            _MATTER_DOMAIN,
+            "get_lock_credential_status",
+            {
+                "entity_id": entity_id,
+                "credential_type": _PIN,
+                "credential_index": slot,
+            },
+            blocking=True,
+            return_response=True,
+        )
+    except Exception:
+        LOGGER.debug(
+            "matter.get_lock_credential_status failed for %s slot %d",
+            entity_id,
+            slot,
+            exc_info=True,
+        )
+        return None
+
+    return _extract_entity_response(response, entity_id)
+
+
+async def _get_lock_info(
+    hass: HomeAssistant, entity_id: str
+) -> Optional[Dict[str, Any]]:
+    try:
+        response = await hass.services.async_call(
+            _MATTER_DOMAIN,
+            "get_lock_info",
+            {"entity_id": entity_id},
+            blocking=True,
+            return_response=True,
+        )
+    except Exception:
+        LOGGER.debug(
+            "matter.get_lock_info failed for %s", entity_id, exc_info=True
+        )
+        return None
+    return _extract_entity_response(response, entity_id)

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -18,21 +18,26 @@ We therefore mirror the flow the official HA Matter Lock Manager UI
 uses, which is known to work on Aqara U200/U300, Yale Assure 2,
 Schlage Sense Pro, Z-Wave-via-Matter bridges, and the Bolt SE.
 
-## Two-path SetCredential by slot occupancy
+## Three-branch SetCredential by slot occupancy and user-group state
 
 We always pre-flight the slot with ``matter.get_lock_credential_status``
 to learn (a) whether HA will pick ``kAdd`` or ``kModify`` and (b) the
-current user_index for Modify.  Then we send a single
-``matter.set_lock_credential`` shaped for that path:
+current user_index for Modify.  On Add we also call
+``matter.get_lock_info`` to learn ``max_credentials_per_user`` (Matter
+§5.2.4.41), and when the lock supports user-stacking (>=2) we probe
+sibling slots in the same user-group to discover an existing
+user_index.  Then we send a single ``matter.set_lock_credential``
+shaped for that branch:
 
-================  ===============  ==========  ==========  =========================
-Slot state        operation        user_index  user_type   user_status
-================  ===============  ==========  ==========  =========================
-Empty (Add)       HA picks kAdd    *null*      ``unrestricted_user``  *null*
-Occupied (Modify) HA picks kModify existing N  *null*      *null*
-================  ===============  ==========  ==========  =========================
+==================================  ===============  ==========  =====================  ===========
+Slot / user-group state             operation        user_index  user_type              user_status
+==================================  ===============  ==========  =====================  ===========
+Empty slot, group has no siblings   HA picks kAdd    *null*      ``unrestricted_user``  *null*
+Empty slot, group has a sibling     HA picks kAdd    discovered  *null*                 *null*
+Occupied slot                       HA picks kModify existing N  *null*                 *null*
+==================================  ===============  ==========  =====================  ===========
 
-Both shapes are spec-compliant per Matter 1.x §5.2.4.40 and the
+All three shapes are spec-compliant per Matter 1.x §5.2.4.40 and the
 connectedhomeip validity check (``DoorLockServer::SetCredential``,
 chip ``16657402aa``):
 
@@ -154,37 +159,73 @@ class MatterLockProvider:
     ) -> ProviderResult:
         """Set a PIN credential for *slot*, auto-creating the user if needed.
 
-        Two-path single ``matter.set_lock_credential`` call, branched on
-        the slot's current occupancy as observed via
-        ``matter.get_lock_credential_status``:
+        Three-branch single ``matter.set_lock_credential`` call.  We
+        first preflight the slot via
+        ``matter.get_lock_credential_status``; on the Add path we also
+        check ``matter.get_lock_info`` for ``max_credentials_per_user``
+        and, when the lock supports user-stacking (Matter §5.2.4.41,
+        e.g. Bolt SE: 5 PINs per user), probe the other slots in the
+        same user-group for an existing user_index:
 
-        * **Empty slot (Add path)** — send ``credential_index=slot``,
-          ``user_index=null``, ``user_type=unrestricted_user``,
-          ``user_status=null``.  HA's helper sees the empty slot and
-          dispatches ``SetCredential(kAdd)``; the lock allocates a
-          fresh user with the supplied user_type and attaches the PIN
-          at our ``credential_index``.
-        * **Occupied slot (Modify path)** — send
+        * **Modify path (slot has a credential)** — send
           ``credential_index=slot``,
           ``user_index=<existing user from GetCredentialStatus>``, both
           ``user_status`` and ``user_type`` null.  HA dispatches
           ``SetCredential(kModify)`` and the lock updates the PIN
           bytes for the existing user.
+        * **Add path, fresh user-group** (no other slot in this
+          credential's user-group is occupied) — send
+          ``credential_index=slot``, ``user_index=null``,
+          ``user_type=unrestricted_user``, ``user_status=null``.  HA
+          dispatches ``SetCredential(kAdd)``; the lock auto-allocates a
+          fresh user with the supplied user_type and attaches the PIN
+          at our ``credential_index``.  This is also the path used for
+          non-stacking locks where ``max_credentials_per_user`` is None
+          or 1.
+        * **Add path, existing user-group** (another slot in this
+          credential's user-group is already occupied) — send
+          ``credential_index=slot``,
+          ``user_index=<discovered from sibling slot>``, both
+          ``user_status`` and ``user_type`` null.  HA dispatches
+          ``SetCredential(kAdd)`` but with a non-null userIndex, so the
+          lock attaches the PIN to the existing user without modifying
+          its attributes.  This is what unlocks user-stacking on the
+          Bolt SE: the lock auto-creates the user only on the first
+          credential, and we attach the rest by discovered user_index.
 
         If the lock returns ``duplicate`` (same PIN bytes already
         programmed), we treat that as a verified no-op so Oban retries
         of an op that succeeded silently the first time still
         converge.
 
-        See the module docstring for why this two-path shape is
-        necessary (Bolt SE rejects ``kAdd`` with non-null userIndex
-        despite the spec).
+        See the module docstring for why we never send a non-null
+        userIndex pointing at an *empty* user slot (Bolt SE rejects
+        that combination despite the spec describing it).
         """
         started_at = time.monotonic()
 
         existing = await _get_credential_status(hass, entity_id, slot)
         is_modify = bool(existing and existing.get("credential_exists"))
         operation = "modify" if is_modify else "add"
+
+        # On the Add path we may need the lock's per-user credential cap to
+        # decide whether to attach to an existing user (user-stacking, e.g.
+        # Bolt SE: 5 PINs per user) or let the lock auto-allocate a fresh
+        # user.  Modify never needs it — we always reuse the credential's
+        # current user_index.
+        max_credentials_per_user: Optional[int] = None
+        stacked_user_index: Optional[int] = None
+        if not is_modify:
+            info = await _get_lock_info(hass, entity_id)
+            if info:
+                max_credentials_per_user = _extract_max_credentials_per_user(info)
+            if (
+                max_credentials_per_user is not None
+                and max_credentials_per_user >= 2
+            ):
+                stacked_user_index = await _find_existing_user_index_in_group(
+                    hass, entity_id, slot, max_credentials_per_user
+                )
 
         request_payload: Dict[str, Any] = {
             "entity_id": entity_id,
@@ -198,18 +239,31 @@ class MatterLockProvider:
                 request_payload["user_index"] = existing_user_index
             # No user_type / user_status: must both be null on Modify
             # when userIndex is non-null (chip SDK validity check).
+        elif stacked_user_index is not None:
+            # Add path, but another credential in this user-group is
+            # already programmed — attach this PIN to the same lock-side
+            # user.  user_index pinpoints the existing user; user_type /
+            # user_status MUST be null so the lock keeps the existing
+            # user record intact (matches HA's "add credential to user"
+            # UI flow on the Bolt SE).
+            request_payload["user_index"] = stacked_user_index
         else:
             # No user_index → null on the wire → lock auto-allocates a
-            # fresh user.  user_type describes that new user.
+            # fresh user.  user_type describes that new user.  This is
+            # also the path for non-stacking locks (1 credential per
+            # user) where ``max_credentials_per_user`` is None or 1.
             request_payload["user_type"] = _USER_TYPE_DEFAULT
         LOGGER.debug(
             "matter.set_lock_credential request: entity_id=%s slot=%d "
-            "operation=%s code_length=%d existing_user_index=%s",
+            "operation=%s code_length=%d user_index=%s "
+            "max_credentials_per_user=%s stacked=%s",
             entity_id,
             slot,
             operation,
             len(code),
             request_payload.get("user_index", "<auto>"),
+            max_credentials_per_user if max_credentials_per_user is not None else "-",
+            stacked_user_index is not None,
         )
 
         set_response: Optional[Dict[str, Any]] = None
@@ -497,10 +551,14 @@ class MatterLockProvider:
             bool(info.get("supports_user_management"))
             and _PIN in (info.get("supported_credential_types") or [])
         )
-        max_slots = info.get("max_pin_users") or info.get("max_users")
+        max_users = _extract_max_users(info)
+        max_credentials_per_user = _extract_max_credentials_per_user(info)
+        max_slots = _derive_max_slots(max_users, max_credentials_per_user)
         return CapabilityInfo(
             supports_access_codes=supports,
             max_slots=max_slots,
+            max_users=max_users,
+            max_credentials_per_user=max_credentials_per_user,
             extra=info,
         )
 
@@ -620,11 +678,17 @@ async def _enrich_with_capacity_context(
     if not info:
         return
 
-    max_slots = info.get("max_pin_users") or info.get("max_users")
+    max_users = _extract_max_users(info)
+    max_credentials_per_user = _extract_max_credentials_per_user(info)
+    max_slots = _derive_max_slots(max_users, max_credentials_per_user)
     if not isinstance(max_slots, int) or max_slots <= 0:
         return
 
     extra["max_slots"] = max_slots
+    if max_users is not None:
+        extra["max_users"] = max_users
+    if max_credentials_per_user is not None:
+        extra["max_credentials_per_user"] = max_credentials_per_user
     extra["slot"] = slot
     if slot > max_slots:
         extra["reason"] = "slot_out_of_range"
@@ -719,6 +783,58 @@ def _format_log_error(error: Optional[str], exc: Optional[BaseException]) -> str
     return "-"
 
 
+async def _find_existing_user_index_in_group(
+    hass: HomeAssistant,
+    entity_id: str,
+    slot: int,
+    max_credentials_per_user: int,
+) -> Optional[int]:
+    """Probe other slots in the same user-group for an existing user_index.
+
+    Matter §5.2.4.41 lets each lock user hold up to
+    ``NumberOfCredentialsSupportedPerUser`` PIN credentials.  To attach a
+    new credential to that user we need its lock-side ``user_index``,
+    which the lock allocates dynamically — we don't pick it.  When adding
+    the second-or-later credential of a user we discover the user_index
+    by reading any other occupied slot in the same group.
+
+    A "user-group" is the contiguous run of credential_index values that
+    map to a single lock user, e.g. with ``max_credentials_per_user=5``:
+
+    ====  ====
+    Slot  User-group
+    ====  ====
+    1-5   group 1 (group_start=1)
+    6-10  group 2 (group_start=6)
+    ...   ...
+    ====  ====
+
+    Returns ``None`` when no other slot in the group is occupied (i.e.
+    this is the first credential of a fresh user — caller should send
+    ``user_index=null`` so the lock auto-allocates).  We probe in slot
+    order to short-circuit on the most common case (group_start was
+    written first), capping the worst-case cost at
+    ``max_credentials_per_user - 1`` ``get_lock_credential_status``
+    calls.
+    """
+    if max_credentials_per_user < 2:
+        return None
+    group_start = (
+        ((slot - 1) // max_credentials_per_user) * max_credentials_per_user + 1
+    )
+    group_end = group_start + max_credentials_per_user - 1
+    for probe_slot in range(group_start, group_end + 1):
+        if probe_slot == slot:
+            continue
+        status = await _get_credential_status(hass, entity_id, probe_slot)
+        if not status or not status.get("credential_exists"):
+            continue
+        user_index = status.get("user_index")
+        if isinstance(user_index, int):
+            return user_index
+    return None
+
+
 async def _get_credential_status(
     hass: HomeAssistant, entity_id: str, slot: int
 ) -> Optional[Dict[str, Any]]:
@@ -763,3 +879,58 @@ async def _get_lock_info(
         )
         return None
     return _extract_entity_response(response, entity_id)
+
+
+def _extract_max_users(info: Dict[str, Any]) -> Optional[int]:
+    """Pick the most-specific PIN-user count from a ``get_lock_info`` payload.
+
+    HA's matter integration may surface ``max_pin_users`` (preferred — that
+    field is the count of PIN-credential users specifically, per
+    ``NumberOfPINUsersSupported``) and/or the broader ``max_users``
+    (``NumberOfTotalUsersSupported``).  Prefer the PIN-specific number when
+    both are present, since users that can't hold PINs aren't useful slots
+    for our purposes.
+    """
+    candidates = (
+        info.get("max_pin_users"),
+        info.get("max_users"),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, int) and candidate > 0:
+            return candidate
+    return None
+
+
+def _extract_max_credentials_per_user(info: Dict[str, Any]) -> Optional[int]:
+    """Pick the per-user credential cap from a ``get_lock_info`` payload.
+
+    Maps to Matter §5.2.4.41 ``NumberOfCredentialsSupportedPerUser``.  The
+    HA Matter integration exposes it as ``max_credentials_per_user``.  We
+    return ``None`` when absent so callers know to fall back to the
+    1-credential-per-user default (which preserves the pre-stacking
+    behaviour).
+    """
+    value = info.get("max_credentials_per_user")
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
+def _derive_max_slots(
+    max_users: Optional[int],
+    max_credentials_per_user: Optional[int],
+) -> Optional[int]:
+    """Compute total effective PIN slots from the two Matter capacity caps.
+
+    With user-stacking (``max_credentials_per_user >= 2``) the lock can
+    hold ``max_users * max_credentials_per_user`` PINs total — e.g. the
+    Bolt SE's 10 users × 5 credentials = 50 slots.  When the per-user cap
+    isn't advertised (or is 1) we fall back to ``max_users`` directly,
+    matching the pre-stacking behaviour.  Returns ``None`` when we can't
+    determine a positive count.
+    """
+    if max_users is None:
+        return None
+    if max_credentials_per_user is None or max_credentials_per_user <= 1:
+        return max_users
+    return max_users * max_credentials_per_user

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -544,14 +544,9 @@ class MatterLockProvider:
             bool(info.get("supports_user_management"))
             and _PIN in (info.get("supported_credential_types") or [])
         )
-        max_users = _extract_max_users(info)
-        max_credentials_per_user = _extract_max_credentials_per_user(info)
-        max_slots = _derive_max_slots(max_users, max_credentials_per_user)
         return CapabilityInfo(
             supports_access_codes=supports,
-            max_slots=max_slots,
-            max_users=max_users,
-            max_credentials_per_user=max_credentials_per_user,
+            max_slots=_extract_max_slots(info),
             extra=info,
         )
 
@@ -671,17 +666,11 @@ async def _enrich_with_capacity_context(
     if not info:
         return
 
-    max_users = _extract_max_users(info)
-    max_credentials_per_user = _extract_max_credentials_per_user(info)
-    max_slots = _derive_max_slots(max_users, max_credentials_per_user)
+    max_slots = _extract_max_slots(info)
     if not isinstance(max_slots, int) or max_slots <= 0:
         return
 
     extra["max_slots"] = max_slots
-    if max_users is not None:
-        extra["max_users"] = max_users
-    if max_credentials_per_user is not None:
-        extra["max_credentials_per_user"] = max_credentials_per_user
     extra["slot"] = slot
     if slot > max_slots:
         extra["reason"] = "slot_out_of_range"
@@ -822,15 +811,25 @@ async def _get_lock_info(
     return _extract_entity_response(response, entity_id)
 
 
-def _extract_max_users(info: Dict[str, Any]) -> Optional[int]:
-    """Pick the most-specific PIN-user count from a ``get_lock_info`` payload.
+def _extract_max_slots(info: Dict[str, Any]) -> Optional[int]:
+    """Pick the PIN slot capacity from a ``get_lock_info`` payload.
 
-    HA's matter integration may surface ``max_pin_users`` (preferred — that
-    field is the count of PIN-credential users specifically, per
+    HA's matter integration may surface ``max_pin_users`` (preferred — the
+    PIN-credential user count specifically, per
     ``NumberOfPINUsersSupported``) and/or the broader ``max_users``
     (``NumberOfTotalUsersSupported``).  Prefer the PIN-specific number when
     both are present, since users that can't hold PINs aren't useful slots
-    for our purposes.
+    for us.
+
+    The Matter spec (§5.2.4.41) implies a lock that also advertises
+    ``NumberOfCredentialsSupportedPerUser = C`` can hold ``U × C`` PIN
+    credentials.  In practice firmware like the Ultraloq Bolt SE enforces
+    a tighter global cap equal to ``U`` even when ``C > 1`` (empirically
+    rejects credential_index 11+ once 10 PIN credentials are programmed,
+    regardless of distribution across users).  We therefore size
+    ``max_slots = max_users`` only; locks that genuinely support the
+    full ``U × C`` cap can override via
+    ``SupportedDevice.default_settings`` in Orion.
     """
     candidates = (
         info.get("max_pin_users"),
@@ -839,48 +838,4 @@ def _extract_max_users(info: Dict[str, Any]) -> Optional[int]:
     for candidate in candidates:
         if isinstance(candidate, int) and candidate > 0:
             return candidate
-    return None
-
-
-def _extract_max_credentials_per_user(info: Dict[str, Any]) -> Optional[int]:
-    """Pick the per-user credential cap from a ``get_lock_info`` payload.
-
-    Maps to Matter §5.2.4.41 ``NumberOfCredentialsSupportedPerUser``.  The
-    HA Matter integration exposes it as ``max_credentials_per_user``.
-
-    We surface this in capability telemetry but no longer use it to
-    influence ``max_slots`` — see ``_derive_max_slots``.  Returns
-    ``None`` when absent.
-    """
-    value = info.get("max_credentials_per_user")
-    if isinstance(value, int) and value > 0:
-        return value
-    return None
-
-
-def _derive_max_slots(
-    max_users: Optional[int],
-    max_credentials_per_user: Optional[int],
-) -> Optional[int]:
-    """Compute the conservative PIN slot capacity from Matter capacity caps.
-
-    The Matter spec (§5.2.4.41) implies a lock that advertises
-    ``NumberOfPINUsersSupported = U`` and
-    ``NumberOfCredentialsSupportedPerUser = C`` can hold ``U × C`` PIN
-    credentials.  In practice some firmware (e.g. Ultraloq Bolt SE)
-    enforces a tighter global cap equal to ``U`` even though the
-    per-user cap is C > 1 — empirically the Bolt SE rejects
-    credential_index 11+ once 10 PIN credentials are programmed,
-    regardless of how those credentials are distributed across users.
-
-    We therefore default ``max_slots`` to ``max_users`` only.
-    Catalogued locks that we verify support the spec's full ``U × C``
-    cap can override ``max_codes`` via
-    ``SupportedDevice.default_settings``.
-
-    Returns ``None`` when we can't determine a positive count.
-    """
-    _ = max_credentials_per_user  # surfaced as telemetry, not used for sizing
-    if isinstance(max_users, int) and max_users > 0:
-        return max_users
     return None

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -35,6 +35,29 @@ user, the lock auto-creates that user with default attributes.  HA's
 "new user + new credential" and "update existing credential" cases for
 arbitrary caller-supplied slot numbers.
 
+## SetCredential parameter conservatism
+
+Real-world testing on the Ultraloq Bolt SE turned up a fresh-Add
+rejection with HA-rendered status ``unknown(133)``.  HA only maps
+DlStatus values 0x00-0x03 in ``SET_CREDENTIAL_STATUS_MAP``, so anything
+else surfaces as ``unknown(<int>)``; ``133 = 0x85`` is the Matter
+Interaction Model ``INVALID_COMMAND`` general status code, which means
+the lock rejected the command before applying it.  The most likely
+irritants the spec marks as caller-optional but some implementations
+choke on:
+
+* ``userStatus`` set explicitly on a fresh ``kAdd``.  Spec says the
+  lock should default to ``kOccupiedEnabled`` when null; the Bolt SE
+  appears to reject the explicit value.  We omit it on the wire and
+  let the lock pick its default.
+* ``userType`` left null on a fresh ``kAdd``.  Spec says the lock
+  should default to ``kUnrestrictedUser``; the Bolt SE appears to
+  require it explicitly.  We always send ``unrestricted_user``.
+
+This keeps the happy path identical for spec-compliant locks (Z-Wave
+locks bridged via Matter, Aqara, Schlage Sense Pro, etc.) while
+unblocking the Bolt SE.
+
 ## Verification semantics
 
 * ``matter.set_lock_credential`` returns its result synchronously
@@ -45,6 +68,11 @@ arbitrary caller-supplied slot numbers.
   same credential bytes are already programmed in that slot — treated
   as a verified no-op (important for Oban retries that succeeded
   silently the first time).
+* On any other rejection we extract the structured Matter status from
+  the exception's ``translation_placeholders`` and surface it both in
+  logs and in ``ProviderResult.extra["matter_status"]`` /
+  ``ProviderResult.error`` so Orion's activity log shows the actual
+  Matter status code rather than just "set_lock_credential failed".
 * As a defensive sanity check we fall back to
   ``matter.get_lock_credential_status`` when the set call returns
   without a usable ``credential_index`` for any other reason.
@@ -67,6 +95,9 @@ LOGGER = logging.getLogger(__name__)
 _MATTER_DOMAIN = "matter"
 _PIN = "pin"
 _USER_TYPE_DEFAULT = "unrestricted_user"
+
+# Kept for backwards compatibility / external readers; no longer sent
+# on set_lock_credential — see module docstring (Bolt SE workaround).
 _USER_STATUS_ENABLED = "occupied_enabled"
 
 # DoorLock SetCredential status codes that are non-fatal for our use
@@ -99,23 +130,36 @@ class MatterLockProvider:
         * If the new PIN bytes match what's already there, the lock
           returns ``duplicate`` status — we treat that as success.
 
+        We deliberately omit ``user_status`` and always send
+        ``user_type=unrestricted_user`` — see this module's docstring
+        for the rationale (Bolt SE Add-rejection workaround).
+
         Falls back to ``matter.get_lock_credential_status`` only if the
         set call returns without a usable ``credential_index`` and
         didn't raise.
         """
+        request_payload: Dict[str, Any] = {
+            "entity_id": entity_id,
+            "credential_type": _PIN,
+            "credential_data": str(code),
+            "credential_index": slot,
+            "user_index": slot,
+            "user_type": _USER_TYPE_DEFAULT,
+        }
+        LOGGER.debug(
+            "matter.set_lock_credential request: entity_id=%s slot=%d "
+            "user_type=%s (user_status omitted intentionally)",
+            entity_id,
+            slot,
+            _USER_TYPE_DEFAULT,
+        )
+
         set_response: Optional[Dict[str, Any]] = None
         try:
             set_response = await hass.services.async_call(
                 _MATTER_DOMAIN,
                 "set_lock_credential",
-                {
-                    "entity_id": entity_id,
-                    "credential_type": _PIN,
-                    "credential_data": str(code),
-                    "credential_index": slot,
-                    "user_index": slot,
-                    "user_status": _USER_STATUS_ENABLED,
-                },
+                request_payload,
                 blocking=True,
                 return_response=True,
             )
@@ -133,14 +177,24 @@ class MatterLockProvider:
                     verified=True,
                     extra={"status": _DUPLICATE_STATUS},
                 )
-            LOGGER.exception(
-                "matter.set_lock_credential failed for %s slot %d", entity_id, slot
+            matter_status = _extract_matter_status(exc)
+            LOGGER.error(
+                "matter.set_lock_credential failed for %s slot %d "
+                "(matter_status=%s): %s",
+                entity_id,
+                slot,
+                matter_status or "<unknown>",
+                exc,
             )
+            extra: Dict[str, Any] = {}
+            if matter_status is not None:
+                extra["matter_status"] = matter_status
             return ProviderResult(
                 slot=slot,
                 method="matter_set_credential",
                 verified=False,
-                error=f"set_lock_credential: {exc}",
+                error=_format_set_error(matter_status, exc),
+                extra=extra,
             )
         except Exception as exc:
             LOGGER.exception(
@@ -292,6 +346,37 @@ def _is_duplicate_credential_error(exc: BaseException) -> bool:
         return True
 
     return _DUPLICATE_STATUS in str(exc).lower()
+
+
+def _extract_matter_status(exc: BaseException) -> Optional[str]:
+    """Pull the structured Matter status out of an HA exception.
+
+    HA's matter lock helpers raise with
+    ``translation_placeholders={"status": "<value>"}`` where ``<value>``
+    is one of the DlStatus strings (``failure``, ``duplicate``,
+    ``occupied``) or ``unknown(<int>)`` for IM-level codes the helper
+    didn't map.  We surface this verbatim so operators can correlate
+    against Matter spec status tables.
+    """
+    placeholders = getattr(exc, "translation_placeholders", None)
+    if isinstance(placeholders, dict):
+        status = placeholders.get("status")
+        if isinstance(status, str) and status:
+            return status
+    return None
+
+
+def _format_set_error(matter_status: Optional[str], exc: BaseException) -> str:
+    """Build the ProviderResult.error string with the Matter status if present.
+
+    Including the status code in the error string means it propagates
+    through Orion's ``DeviceService.classify_action_body/1`` /
+    ``ActivityService.format_error_reason/1`` chain into the user-facing
+    activity log without any further plumbing.
+    """
+    if matter_status:
+        return f"set_lock_credential: matter_status={matter_status}: {exc}"
+    return f"set_lock_credential: {exc}"
 
 
 async def _get_credential_status(

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -18,26 +18,33 @@ We therefore mirror the flow the official HA Matter Lock Manager UI
 uses, which is known to work on Aqara U200/U300, Yale Assure 2,
 Schlage Sense Pro, Z-Wave-via-Matter bridges, and the Bolt SE.
 
-## Three-branch SetCredential by slot occupancy and user-group state
+## Two-branch SetCredential by slot occupancy
 
-We always pre-flight the slot with ``matter.get_lock_credential_status``
-to learn (a) whether HA will pick ``kAdd`` or ``kModify`` and (b) the
-current user_index for Modify.  On Add we also call
-``matter.get_lock_info`` to learn ``max_credentials_per_user`` (Matter
-§5.2.4.41), and when the lock supports user-stacking (>=2) we probe
-sibling slots in the same user-group to discover an existing
-user_index.  Then we send a single ``matter.set_lock_credential``
-shaped for that branch:
+We pre-flight the slot with ``matter.get_lock_credential_status`` to
+learn (a) whether HA will pick ``kAdd`` or ``kModify`` and (b) the
+current user_index for Modify.  Then we send a single
+``matter.set_lock_credential`` shaped for that branch:
 
-==================================  ===============  ==========  =====================  ===========
-Slot / user-group state             operation        user_index  user_type              user_status
-==================================  ===============  ==========  =====================  ===========
-Empty slot, group has no siblings   HA picks kAdd    *null*      ``unrestricted_user``  *null*
-Empty slot, group has a sibling     HA picks kAdd    discovered  *null*                 *null*
-Occupied slot                       HA picks kModify existing N  *null*                 *null*
-==================================  ===============  ==========  =====================  ===========
+==================================  ================  ==========  =====================  ===========
+Slot state                          operation         user_index  user_type              user_status
+==================================  ================  ==========  =====================  ===========
+Empty slot                          HA picks kAdd     *null*      ``unrestricted_user``  *null*
+Occupied slot                       HA picks kModify  existing N  *null*                 *null*
+==================================  ================  ==========  =====================  ===========
 
-All three shapes are spec-compliant per Matter 1.x §5.2.4.40 and the
+We considered user-stacking (multiple PIN credentials sharing one
+``user_index``) per Matter §5.2.4.41 — the Bolt SE advertises 5 PINs
+per user, which would have notionally given us 50 effective slots.
+Empirically the Bolt SE caps total PIN credentials globally at
+``max_pin_users`` regardless of distribution, so stacking provided no
+capacity benefit; HA's matter integration also doesn't currently
+surface ``user_index`` on ``LockOperation`` events, so the
+recipient-resolution argument disappears too.  We removed the
+sibling-slot probe; if a future use case revives stacking, the probe
+logic is in this module's git history (commits ``b2f1c…`` and
+``397f13e``).
+
+Both shapes are spec-compliant per Matter 1.x §5.2.4.40 and the
 connectedhomeip validity check (``DoorLockServer::SetCredential``,
 chip ``16657402aa``):
 
@@ -176,13 +183,9 @@ class MatterLockProvider:
     ) -> ProviderResult:
         """Set a PIN credential for *slot*, auto-creating the user if needed.
 
-        Three-branch single ``matter.set_lock_credential`` call.  We
-        first preflight the slot via
-        ``matter.get_lock_credential_status``; on the Add path we also
-        check ``matter.get_lock_info`` for ``max_credentials_per_user``
-        and, when the lock supports user-stacking (Matter §5.2.4.41,
-        e.g. Bolt SE: 5 PINs per user), probe the other slots in the
-        same user-group for an existing user_index:
+        Two-branch single ``matter.set_lock_credential`` call.  We
+        preflight the slot via ``matter.get_lock_credential_status`` to
+        decide between Add and Modify:
 
         * **Modify path (slot has a credential)** — send
           ``credential_index=slot``,
@@ -190,25 +193,27 @@ class MatterLockProvider:
           ``user_status`` and ``user_type`` null.  HA dispatches
           ``SetCredential(kModify)`` and the lock updates the PIN
           bytes for the existing user.
-        * **Add path, fresh user-group** (no other slot in this
-          credential's user-group is occupied) — send
+        * **Add path (slot is empty)** — send
           ``credential_index=slot``, ``user_index=null``,
           ``user_type=unrestricted_user``, ``user_status=null``.  HA
           dispatches ``SetCredential(kAdd)``; the lock auto-allocates a
           fresh user with the supplied user_type and attaches the PIN
-          at our ``credential_index``.  This is also the path used for
-          non-stacking locks where ``max_credentials_per_user`` is None
-          or 1.
-        * **Add path, existing user-group** (another slot in this
-          credential's user-group is already occupied) — send
-          ``credential_index=slot``,
-          ``user_index=<discovered from sibling slot>``, both
-          ``user_status`` and ``user_type`` null.  HA dispatches
-          ``SetCredential(kAdd)`` but with a non-null userIndex, so the
-          lock attaches the PIN to the existing user without modifying
-          its attributes.  This is what unlocks user-stacking on the
-          Bolt SE: the lock auto-creates the user only on the first
-          credential, and we attach the rest by discovered user_index.
+          at our ``credential_index``.  Each Staykey-managed credential
+          gets its own auto-allocated user — we don't try to stack
+          multiple credentials onto a single ``user_index``.
+
+        We considered user-stacking (multiple PIN credentials sharing
+        one ``user_index``) per Matter §5.2.4.41 — on the Ultraloq
+        Bolt SE that allows up to 5 PINs per user.  In practice it
+        provided no capacity benefit (the Bolt SE caps total PIN
+        credentials globally at ``max_pin_users``, regardless of
+        distribution) and HA's matter integration doesn't currently
+        surface ``user_index`` on ``LockOperation`` events anyway, so
+        the recipient-resolution argument disappears.  Keeping each
+        credential under its own user keeps the data model simple and
+        unambiguous; if a future use case revives stacking, the probe
+        logic is in this module's git history (commits ``b2f1c…`` and
+        ``397f13e``).
 
         If the lock returns ``duplicate`` (same PIN bytes already
         programmed), we treat that as a verified no-op so Oban retries
@@ -225,25 +230,6 @@ class MatterLockProvider:
         is_modify = bool(existing and existing.get("credential_exists"))
         operation = "modify" if is_modify else "add"
 
-        # On the Add path we may need the lock's per-user credential cap to
-        # decide whether to attach to an existing user (user-stacking, e.g.
-        # Bolt SE: 5 PINs per user) or let the lock auto-allocate a fresh
-        # user.  Modify never needs it — we always reuse the credential's
-        # current user_index.
-        max_credentials_per_user: Optional[int] = None
-        stacked_user_index: Optional[int] = None
-        if not is_modify:
-            info = await _get_lock_info(hass, entity_id)
-            if info:
-                max_credentials_per_user = _extract_max_credentials_per_user(info)
-            if (
-                max_credentials_per_user is not None
-                and max_credentials_per_user >= 2
-            ):
-                stacked_user_index = await _find_existing_user_index_in_group(
-                    hass, entity_id, slot, max_credentials_per_user
-                )
-
         request_payload: Dict[str, Any] = {
             "entity_id": entity_id,
             "credential_type": _PIN,
@@ -256,34 +242,21 @@ class MatterLockProvider:
                 request_payload["user_index"] = existing_user_index
             # No user_type / user_status: must both be null on Modify
             # when userIndex is non-null (chip SDK validity check).
-        elif stacked_user_index is not None:
-            # Add path, but another credential in this user-group is
-            # already programmed — attach this PIN to the same lock-side
-            # user.  user_index pinpoints the existing user; user_type /
-            # user_status MUST be null so the lock keeps the existing
-            # user record intact (matches HA's "add credential to user"
-            # UI flow on the Bolt SE).
-            request_payload["user_index"] = stacked_user_index
         else:
             # No user_index → null on the wire → lock auto-allocates a
             # fresh user.  ``user_type`` describes the auto-created
             # user; ``user_status`` is intentionally omitted (see the
             # ``_USER_TYPE_DEFAULT`` constant for why — sending it
-            # actively breaks the Bolt SE).  This is also the path for
-            # non-stacking locks (1 credential per user) where
-            # ``max_credentials_per_user`` is None or 1.
+            # actively breaks the Bolt SE).
             request_payload["user_type"] = _USER_TYPE_DEFAULT
         LOGGER.debug(
             "matter.set_lock_credential request: entity_id=%s slot=%d "
-            "operation=%s code_length=%d user_index=%s "
-            "max_credentials_per_user=%s stacked=%s",
+            "operation=%s code_length=%d user_index=%s",
             entity_id,
             slot,
             operation,
             len(code),
             request_payload.get("user_index", "<auto>"),
-            max_credentials_per_user if max_credentials_per_user is not None else "-",
-            stacked_user_index is not None,
         )
 
         set_response: Optional[Dict[str, Any]] = None
@@ -803,58 +776,6 @@ def _format_log_error(error: Optional[str], exc: Optional[BaseException]) -> str
     return "-"
 
 
-async def _find_existing_user_index_in_group(
-    hass: HomeAssistant,
-    entity_id: str,
-    slot: int,
-    max_credentials_per_user: int,
-) -> Optional[int]:
-    """Probe other slots in the same user-group for an existing user_index.
-
-    Matter §5.2.4.41 lets each lock user hold up to
-    ``NumberOfCredentialsSupportedPerUser`` PIN credentials.  To attach a
-    new credential to that user we need its lock-side ``user_index``,
-    which the lock allocates dynamically — we don't pick it.  When adding
-    the second-or-later credential of a user we discover the user_index
-    by reading any other occupied slot in the same group.
-
-    A "user-group" is the contiguous run of credential_index values that
-    map to a single lock user, e.g. with ``max_credentials_per_user=5``:
-
-    ====  ====
-    Slot  User-group
-    ====  ====
-    1-5   group 1 (group_start=1)
-    6-10  group 2 (group_start=6)
-    ...   ...
-    ====  ====
-
-    Returns ``None`` when no other slot in the group is occupied (i.e.
-    this is the first credential of a fresh user — caller should send
-    ``user_index=null`` so the lock auto-allocates).  We probe in slot
-    order to short-circuit on the most common case (group_start was
-    written first), capping the worst-case cost at
-    ``max_credentials_per_user - 1`` ``get_lock_credential_status``
-    calls.
-    """
-    if max_credentials_per_user < 2:
-        return None
-    group_start = (
-        ((slot - 1) // max_credentials_per_user) * max_credentials_per_user + 1
-    )
-    group_end = group_start + max_credentials_per_user - 1
-    for probe_slot in range(group_start, group_end + 1):
-        if probe_slot == slot:
-            continue
-        status = await _get_credential_status(hass, entity_id, probe_slot)
-        if not status or not status.get("credential_exists"):
-            continue
-        user_index = status.get("user_index")
-        if isinstance(user_index, int):
-            return user_index
-    return None
-
-
 async def _get_credential_status(
     hass: HomeAssistant, entity_id: str, slot: int
 ) -> Optional[Dict[str, Any]]:
@@ -925,10 +846,11 @@ def _extract_max_credentials_per_user(info: Dict[str, Any]) -> Optional[int]:
     """Pick the per-user credential cap from a ``get_lock_info`` payload.
 
     Maps to Matter §5.2.4.41 ``NumberOfCredentialsSupportedPerUser``.  The
-    HA Matter integration exposes it as ``max_credentials_per_user``.  We
-    return ``None`` when absent so callers know to fall back to the
-    1-credential-per-user default (which preserves the pre-stacking
-    behaviour).
+    HA Matter integration exposes it as ``max_credentials_per_user``.
+
+    We surface this in capability telemetry but no longer use it to
+    influence ``max_slots`` — see ``_derive_max_slots``.  Returns
+    ``None`` when absent.
     """
     value = info.get("max_credentials_per_user")
     if isinstance(value, int) and value > 0:
@@ -952,18 +874,13 @@ def _derive_max_slots(
     regardless of how those credentials are distributed across users.
 
     We therefore default ``max_slots`` to ``max_users`` only.
-    User-stacking (multiple credentials sharing one ``user_index``) is
-    still supported on the wire — see ``set_code`` and
-    ``_find_existing_user_index_in_group`` — because it has
-    architectural value beyond raw capacity (recipient resolution,
-    keeping a guest's stay-+-cleaning credentials under one lock-side
-    user, etc.).  Catalogued locks that we verify support the spec's
-    full ``U × C`` cap can override ``max_codes`` via
+    Catalogued locks that we verify support the spec's full ``U × C``
+    cap can override ``max_codes`` via
     ``SupportedDevice.default_settings``.
 
     Returns ``None`` when we can't determine a positive count.
     """
-    _ = max_credentials_per_user  # consulted by callers, not max-slots derivation
+    _ = max_credentials_per_user  # surfaced as telemetry, not used for sizing
     if isinstance(max_users, int) and max_users > 0:
         return max_users
     return None

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -29,22 +29,28 @@ sibling slots in the same user-group to discover an existing
 user_index.  Then we send a single ``matter.set_lock_credential``
 shaped for that branch:
 
-==================================  ===============  ==========  =====================  ===========
+==================================  ===============  ==========  =====================  ====================
 Slot / user-group state             operation        user_index  user_type              user_status
-==================================  ===============  ==========  =====================  ===========
-Empty slot, group has no siblings   HA picks kAdd    *null*      ``unrestricted_user``  *null*
+==================================  ===============  ==========  =====================  ====================
+Empty slot, group has no siblings   HA picks kAdd    *null*      ``unrestricted_user``  ``occupied_enabled``
 Empty slot, group has a sibling     HA picks kAdd    discovered  *null*                 *null*
 Occupied slot                       HA picks kModify existing N  *null*                 *null*
-==================================  ===============  ==========  =====================  ===========
+==================================  ===============  ==========  =====================  ====================
 
 All three shapes are spec-compliant per Matter 1.x §5.2.4.40 and the
 connectedhomeip validity check (``DoorLockServer::SetCredential``,
 chip ``16657402aa``):
 
 * **Add + userIndex null** → ``userStatus`` and ``userType`` describe
-  the user the lock will auto-create.  Sending ``user_type =
-  unrestricted_user`` here is exactly what the HA Matter Lock Manager
-  frontend does (and what works on the Bolt SE).
+  the user the lock will auto-create.  We send ``user_type =
+  unrestricted_user`` *and* ``user_status = occupied_enabled`` here to
+  match HA's own ``set_lock_user`` defaults (line 357–364 of
+  ``lock_helpers.py``).  Omitting ``user_status`` lets the underlying
+  SDK pass ``userStatus = null`` to the lock; on the Ultraloq Bolt SE
+  that produces a fully written-but-disabled user, so SetCredential
+  returns ``kSuccess`` (``verified=true`` from our side) but the keypad
+  rejects every PIN.  Passing ``occupied_enabled`` is what the HA Lock
+  Manager UI does and what the Bolt SE actually accepts.
 * **Modify + userIndex non-null** → ``userStatus`` and ``userType``
   MUST both be null; the lock keeps the existing user attributes and
   only swaps the PIN bytes.
@@ -130,6 +136,20 @@ _PIN = "pin"
 # Matches HA's ``USER_TYPE_MAP`` enum — sent on the wire for the Add
 # path so the lock auto-creates a non-restricted (always-valid) user.
 _USER_TYPE_DEFAULT = "unrestricted_user"
+
+# Matches HA's ``USER_STATUS_MAP`` enum.  Sent alongside
+# ``_USER_TYPE_DEFAULT`` on the fresh-user Add path so the auto-created
+# user lands in the active state.  ``matter.set_lock_credential`` will
+# pass ``userStatus=null`` to the SDK when this argument is omitted, and
+# at least one real-world lock (Ultraloq Bolt SE) interprets a null
+# userStatus on user creation as "store the credential but leave the
+# user disabled" — the credential then verifies at the protocol level
+# (SetCredential returns kSuccess) but the keypad rejects every PIN.
+# Passing ``occupied_enabled`` mirrors what HA's own set_lock_user
+# defaults to for new-user creation and what the HA Lock Manager UI
+# sends when programming a fresh PIN, both of which are confirmed
+# working on the Bolt SE.
+_USER_STATUS_DEFAULT = "occupied_enabled"
 
 # DoorLock SetCredential status codes that are non-fatal for our use
 # case.  Mapped from chip.clusters.DoorLock.Enums.DlStatus by HA in
@@ -249,10 +269,16 @@ class MatterLockProvider:
             request_payload["user_index"] = stacked_user_index
         else:
             # No user_index → null on the wire → lock auto-allocates a
-            # fresh user.  user_type describes that new user.  This is
-            # also the path for non-stacking locks (1 credential per
-            # user) where ``max_credentials_per_user`` is None or 1.
+            # fresh user.  user_type and user_status describe that new
+            # user.  Both are required: omitting user_status causes
+            # firmware like the Ultraloq Bolt SE to leave the user
+            # disabled (writes accepted at the protocol level but the
+            # PIN is rejected at the keypad — exactly the symptom that
+            # used to bite us before this fix).  This is also the path
+            # for non-stacking locks (1 credential per user) where
+            # ``max_credentials_per_user`` is None or 1.
             request_payload["user_type"] = _USER_TYPE_DEFAULT
+            request_payload["user_status"] = _USER_STATUS_DEFAULT
         LOGGER.debug(
             "matter.set_lock_credential request: entity_id=%s slot=%d "
             "operation=%s code_length=%d user_index=%s "

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -920,17 +920,30 @@ def _derive_max_slots(
     max_users: Optional[int],
     max_credentials_per_user: Optional[int],
 ) -> Optional[int]:
-    """Compute total effective PIN slots from the two Matter capacity caps.
+    """Compute the conservative PIN slot capacity from Matter capacity caps.
 
-    With user-stacking (``max_credentials_per_user >= 2``) the lock can
-    hold ``max_users * max_credentials_per_user`` PINs total — e.g. the
-    Bolt SE's 10 users × 5 credentials = 50 slots.  When the per-user cap
-    isn't advertised (or is 1) we fall back to ``max_users`` directly,
-    matching the pre-stacking behaviour.  Returns ``None`` when we can't
-    determine a positive count.
+    The Matter spec (§5.2.4.41) implies a lock that advertises
+    ``NumberOfPINUsersSupported = U`` and
+    ``NumberOfCredentialsSupportedPerUser = C`` can hold ``U × C`` PIN
+    credentials.  In practice some firmware (e.g. Ultraloq Bolt SE)
+    enforces a tighter global cap equal to ``U`` even though the
+    per-user cap is C > 1 — empirically the Bolt SE rejects
+    credential_index 11+ once 10 PIN credentials are programmed,
+    regardless of how those credentials are distributed across users.
+
+    We therefore default ``max_slots`` to ``max_users`` only.
+    User-stacking (multiple credentials sharing one ``user_index``) is
+    still supported on the wire — see ``set_code`` and
+    ``_find_existing_user_index_in_group`` — because it has
+    architectural value beyond raw capacity (recipient resolution,
+    keeping a guest's stay-+-cleaning credentials under one lock-side
+    user, etc.).  Catalogued locks that we verify support the spec's
+    full ``U × C`` cap can override ``max_codes`` via
+    ``SupportedDevice.default_settings``.
+
+    Returns ``None`` when we can't determine a positive count.
     """
-    if max_users is None:
-        return None
-    if max_credentials_per_user is None or max_credentials_per_user <= 1:
+    _ = max_credentials_per_user  # consulted by callers, not max-slots derivation
+    if isinstance(max_users, int) and max_users > 0:
         return max_users
-    return max_users * max_credentials_per_user
+    return None

--- a/custom_components/staykey/services/providers/matter.py
+++ b/custom_components/staykey/services/providers/matter.py
@@ -19,44 +19,50 @@ slot-based callers:
 * If you pass ``user_index=N``, HA does ``GetUser(N)`` first.  If the
   slot is empty it raises ``UserSlotEmptyError("User slot N is empty")``
   (intended to prevent accidentally Adding when you meant to Modify).
-  If the slot is occupied, HA sends ``SetUser(kModify, ...)`` which
-  some Matter locks (Ultraloq Bolt SE confirmed) reject with
-  ``InvalidCommand (0x85)``.
 * The "auto-allocate empty slot then Add" branch only runs when
   ``user_index=None``, which would force us to give up the
   ``slot == user_index`` invariant.
 
 Per the Matter 1.x spec (DoorLock cluster, SetCredential command), when
 ``operationType=kAdd`` and ``userIndex`` references a non-existent
-user, the lock auto-creates that user with default attributes.  HA's
+user, the lock auto-creates that user with default attributes
+(``kOccupiedEnabled`` / ``kUnrestrictedUser`` / ``kSingle``).  HA's
 ``set_lock_credential`` helper picks Add vs Modify based on the
-**credential** slot's occupancy (no empty-slot guard), so a single
-``set_lock_credential`` call with ``user_index=slot`` covers both the
-"new user + new credential" and "update existing credential" cases for
-arbitrary caller-supplied slot numbers.
+**credential** slot's occupancy, so a single ``set_lock_credential``
+call with ``user_index=slot`` covers both the "new user + new
+credential" and "update existing credential" cases for arbitrary
+caller-supplied slot numbers.
 
-## SetCredential parameter conservatism
+## SetCredential parameter rules (and the 0x85 trap)
 
-Real-world testing on the Ultraloq Bolt SE turned up a fresh-Add
-rejection with HA-rendered status ``unknown(133)``.  HA only maps
-DlStatus values 0x00-0x03 in ``SET_CREDENTIAL_STATUS_MAP``, so anything
-else surfaces as ``unknown(<int>)``; ``133 = 0x85`` is the Matter
-Interaction Model ``INVALID_COMMAND`` general status code, which means
-the lock rejected the command before applying it.  The most likely
-irritants the spec marks as caller-optional but some implementations
-choke on:
+Matter spec ``5.2.4.40`` and connectedhomeip's validity check
+(``DoorLockServer::SetCredential``, chip commit ``16657402aa``) require:
 
-* ``userStatus`` set explicitly on a fresh ``kAdd``.  Spec says the
-  lock should default to ``kOccupiedEnabled`` when null; the Bolt SE
-  appears to reject the explicit value.  We omit it on the wire and
-  let the lock pick its default.
-* ``userType`` left null on a fresh ``kAdd``.  Spec says the lock
-  should default to ``kUnrestrictedUser``; the Bolt SE appears to
-  require it explicitly.  We always send ``unrestricted_user``.
+* ``OperationType=Add`` with ``userIndex`` non-null
+  → ``userStatus`` and ``userType`` **MUST both be null**.
+* ``OperationType=Modify`` with ``userIndex`` non-null
+  → ``userStatus`` and ``userType`` **MUST both be null**.
 
-This keeps the happy path identical for spec-compliant locks (Z-Wave
-locks bridged via Matter, Aqara, Schlage Sense Pro, etc.) while
-unblocking the Bolt SE.
+If either field is non-null the Matter SDK rejects the command with
+``DlStatus::kInvalidField``, which surfaces over the Interaction Model
+as ``Status::InvalidCommand`` (``0x85`` = ``133``).  HA's
+``SET_CREDENTIAL_STATUS_MAP`` only maps the four lock-level DlStatus
+values (success / failure / duplicate / occupied), so 0x85 renders as
+``unknown(133)``.
+
+We therefore send **only** ``credential_type``, ``credential_data``,
+``credential_index``, and ``user_index`` to ``set_lock_credential``.
+The lock auto-creates the user with ``kUnrestrictedUser`` /
+``kOccupiedEnabled`` defaults on Add — exactly what we want.  This
+matches the spec for the entire compliant lock fleet (Aqara U200/U300,
+Schlage Sense Pro, Yale Assure 2, Z-Wave locks bridged via Matter, and
+the Ultraloq Bolt SE / Bolt Fingerprint).
+
+> Earlier revisions of this provider sent ``user_type=unrestricted_user``
+> believing the Bolt SE required it explicitly; that turned out to be
+> the cause of the 0x85 rejection rather than the cure (the SDK
+> validity check fires before the lock vendor logic gets to look at
+> the command).
 
 ## Verification semantics
 
@@ -76,11 +82,21 @@ unblocking the Bolt SE.
 * As a defensive sanity check we fall back to
   ``matter.get_lock_credential_status`` when the set call returns
   without a usable ``credential_index`` for any other reason.
+
+## Wide-event logging
+
+Every ``set_code`` / ``clear_code`` attempt emits a single
+``INFO``-level structured log line on completion with: ``entity_id``,
+``slot``, ``method``, ``verified``, ``matter_status``,
+``duration_ms``, and ``error`` (if any).  The PIN bytes are never
+logged; only ``code_length`` is included so you can correlate length-
+related rejections without leaking secrets.
 """
 
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from homeassistant.exceptions import HomeAssistantError
@@ -94,11 +110,6 @@ LOGGER = logging.getLogger(__name__)
 
 _MATTER_DOMAIN = "matter"
 _PIN = "pin"
-_USER_TYPE_DEFAULT = "unrestricted_user"
-
-# Kept for backwards compatibility / external readers; no longer sent
-# on set_lock_credential — see module docstring (Bolt SE workaround).
-_USER_STATUS_ENABLED = "occupied_enabled"
 
 # DoorLock SetCredential status codes that are non-fatal for our use
 # case.  Mapped from chip.clusters.DoorLock.Enums.DlStatus by HA in
@@ -124,34 +135,36 @@ class MatterLockProvider:
 
         * If ``credential_index=slot`` is empty, HA sends ``kAdd``; the
           Matter spec auto-creates user ``slot`` with default attributes
+          (``kOccupiedEnabled`` / ``kUnrestrictedUser`` / ``kSingle``)
           and attaches the PIN to it.
         * If the slot already holds a credential, HA sends ``kModify``
           to update the PIN bytes.
         * If the new PIN bytes match what's already there, the lock
           returns ``duplicate`` status — we treat that as success.
 
-        We deliberately omit ``user_status`` and always send
-        ``user_type=unrestricted_user`` — see this module's docstring
-        for the rationale (Bolt SE Add-rejection workaround).
+        We deliberately send neither ``user_status`` nor ``user_type``:
+        per Matter spec ``5.2.4.40`` (and the chip SDK validity check)
+        both fields MUST be null when ``userIndex`` is non-null on Add
+        or Modify.  See module docstring for the full rationale.
 
         Falls back to ``matter.get_lock_credential_status`` only if the
         set call returns without a usable ``credential_index`` and
         didn't raise.
         """
+        started_at = time.monotonic()
         request_payload: Dict[str, Any] = {
             "entity_id": entity_id,
             "credential_type": _PIN,
             "credential_data": str(code),
             "credential_index": slot,
             "user_index": slot,
-            "user_type": _USER_TYPE_DEFAULT,
         }
         LOGGER.debug(
             "matter.set_lock_credential request: entity_id=%s slot=%d "
-            "user_type=%s (user_status omitted intentionally)",
+            "code_length=%d (user_status / user_type omitted per Matter spec)",
             entity_id,
             slot,
-            _USER_TYPE_DEFAULT,
+            len(code),
         )
 
         set_response: Optional[Dict[str, Any]] = None
@@ -165,51 +178,45 @@ class MatterLockProvider:
             )
         except HomeAssistantError as exc:
             if _is_duplicate_credential_error(exc):
-                LOGGER.info(
-                    "matter.set_lock_credential reported duplicate for %s slot %d; "
-                    "treating as verified no-op",
-                    entity_id,
-                    slot,
-                )
-                return ProviderResult(
+                result = ProviderResult(
                     slot=slot,
                     method="matter_set_credential_duplicate",
                     verified=True,
                     extra={"status": _DUPLICATE_STATUS},
                 )
+                _log_set_outcome(entity_id, slot, code, started_at, result)
+                return result
             matter_status = _extract_matter_status(exc)
-            LOGGER.error(
-                "matter.set_lock_credential failed for %s slot %d "
-                "(matter_status=%s): %s",
-                entity_id,
-                slot,
-                matter_status or "<unknown>",
-                exc,
-            )
             extra: Dict[str, Any] = {}
             if matter_status is not None:
                 extra["matter_status"] = matter_status
-            return ProviderResult(
+            result = ProviderResult(
                 slot=slot,
                 method="matter_set_credential",
                 verified=False,
                 error=_format_set_error(matter_status, exc),
                 extra=extra,
             )
-        except Exception as exc:
-            LOGGER.exception(
-                "matter.set_lock_credential failed for %s slot %d", entity_id, slot
-            )
-            return ProviderResult(
+            _log_set_outcome(entity_id, slot, code, started_at, result, exc=exc)
+            return result
+        except Exception as exc:  # pragma: no cover - belt-and-suspenders
+            result = ProviderResult(
                 slot=slot,
                 method="matter_set_credential",
                 verified=False,
                 error=f"set_lock_credential: {exc}",
             )
+            LOGGER.exception(
+                "matter.set_lock_credential raised non-HA exception for %s slot %d",
+                entity_id,
+                slot,
+            )
+            _log_set_outcome(entity_id, slot, code, started_at, result, exc=exc)
+            return result
 
         per_entity = _extract_entity_response(set_response, entity_id)
         if per_entity and per_entity.get("credential_index") is not None:
-            return ProviderResult(
+            result = ProviderResult(
                 slot=slot,
                 method="matter_set_credential",
                 verified=True,
@@ -219,22 +226,28 @@ class MatterLockProvider:
                     "next_credential_index": per_entity.get("next_credential_index"),
                 },
             )
+            _log_set_outcome(entity_id, slot, code, started_at, result)
+            return result
 
         status = await _get_credential_status(hass, entity_id, slot)
         if status and status.get("credential_exists"):
-            return ProviderResult(
+            result = ProviderResult(
                 slot=slot,
                 method="matter_active_read",
                 verified=True,
                 extra={"user_index": status.get("user_index")},
             )
+            _log_set_outcome(entity_id, slot, code, started_at, result)
+            return result
 
-        return ProviderResult(
+        result = ProviderResult(
             slot=slot,
             method="matter_set_credential",
             verified=False,
             error="set_lock_credential returned no credential_index and active read did not confirm",
         )
+        _log_set_outcome(entity_id, slot, code, started_at, result)
+        return result
 
     async def clear_code(
         self,
@@ -248,6 +261,7 @@ class MatterLockProvider:
         and schedules in one operation, so we don't need to call
         ``clear_lock_credential`` separately.
         """
+        started_at = time.monotonic()
         try:
             await hass.services.async_call(
                 _MATTER_DOMAIN,
@@ -255,18 +269,38 @@ class MatterLockProvider:
                 {"entity_id": entity_id, "user_index": slot},
                 blocking=True,
             )
-        except Exception as exc:
-            LOGGER.exception(
-                "matter.clear_lock_user failed for %s slot %d", entity_id, slot
+        except HomeAssistantError as exc:
+            matter_status = _extract_matter_status(exc)
+            extra: Dict[str, Any] = {}
+            if matter_status is not None:
+                extra["matter_status"] = matter_status
+            result = ProviderResult(
+                slot=slot,
+                method="matter_clear_user",
+                verified=False,
+                error=_format_clear_error(matter_status, exc),
+                extra=extra,
             )
-            return ProviderResult(
+            _log_clear_outcome(entity_id, slot, started_at, result, exc=exc)
+            return result
+        except Exception as exc:  # pragma: no cover - belt-and-suspenders
+            result = ProviderResult(
                 slot=slot,
                 method="matter_clear_user",
                 verified=False,
                 error=f"clear_lock_user: {exc}",
             )
+            LOGGER.exception(
+                "matter.clear_lock_user raised non-HA exception for %s slot %d",
+                entity_id,
+                slot,
+            )
+            _log_clear_outcome(entity_id, slot, started_at, result, exc=exc)
+            return result
 
-        return ProviderResult(slot=slot, method="matter_clear_user", verified=True)
+        result = ProviderResult(slot=slot, method="matter_clear_user", verified=True)
+        _log_clear_outcome(entity_id, slot, started_at, result)
+        return result
 
     async def read_codes(
         self,
@@ -377,6 +411,78 @@ def _format_set_error(matter_status: Optional[str], exc: BaseException) -> str:
     if matter_status:
         return f"set_lock_credential: matter_status={matter_status}: {exc}"
     return f"set_lock_credential: {exc}"
+
+
+def _format_clear_error(matter_status: Optional[str], exc: BaseException) -> str:
+    """Mirror of ``_format_set_error`` for the clear path."""
+    if matter_status:
+        return f"clear_lock_user: matter_status={matter_status}: {exc}"
+    return f"clear_lock_user: {exc}"
+
+
+def _log_set_outcome(
+    entity_id: str,
+    slot: int,
+    code: str,
+    started_at: float,
+    result: ProviderResult,
+    *,
+    exc: Optional[BaseException] = None,
+) -> None:
+    """Emit one structured wide-event log line per ``set_code`` attempt.
+
+    PIN bytes are never logged; only the length so length-related
+    rejections (``MinPINCodeLength`` / ``MaxPINCodeLength``) can be
+    correlated against lock attributes without leaking secrets.
+    """
+    duration_ms = int((time.monotonic() - started_at) * 1000)
+    matter_status = result.extra.get("matter_status") or result.extra.get("status")
+    log_fn = LOGGER.info if result.verified else LOGGER.error
+    log_fn(
+        "matter set_code outcome entity_id=%s slot=%d code_length=%d "
+        "method=%s verified=%s matter_status=%s duration_ms=%d error=%s",
+        entity_id,
+        slot,
+        len(code),
+        result.method,
+        result.verified,
+        matter_status or "-",
+        duration_ms,
+        _format_log_error(result.error, exc),
+    )
+
+
+def _log_clear_outcome(
+    entity_id: str,
+    slot: int,
+    started_at: float,
+    result: ProviderResult,
+    *,
+    exc: Optional[BaseException] = None,
+) -> None:
+    """Emit one structured wide-event log line per ``clear_code`` attempt."""
+    duration_ms = int((time.monotonic() - started_at) * 1000)
+    matter_status = result.extra.get("matter_status")
+    log_fn = LOGGER.info if result.verified else LOGGER.error
+    log_fn(
+        "matter clear_code outcome entity_id=%s slot=%d "
+        "method=%s verified=%s matter_status=%s duration_ms=%d error=%s",
+        entity_id,
+        slot,
+        result.method,
+        result.verified,
+        matter_status or "-",
+        duration_ms,
+        _format_log_error(result.error, exc),
+    )
+
+
+def _format_log_error(error: Optional[str], exc: Optional[BaseException]) -> str:
+    if error:
+        return error
+    if exc is not None:
+        return f"{type(exc).__name__}: {exc}"
+    return "-"
 
 
 async def _get_credential_status(

--- a/custom_components/staykey/services/providers/zwave.py
+++ b/custom_components/staykey/services/providers/zwave.py
@@ -347,9 +347,14 @@ async def _set_and_verify_code(
                     attempts=attempt + 1,
                 )
             elif result:
+                # NEVER include raw PINs in error strings — they can appear
+                # in activity history and aggregated logs. Compare lengths only.
+                actual = result.get("code")
+                expected_len = len(str(code))
+                actual_len = len(str(actual)) if actual is not None else 0
                 last_error = (
-                    f"Slot {slot} readback mismatch: expected {code}, "
-                    f"got {result.get('code')}"
+                    f"Slot {slot} readback mismatch (expected_length={expected_len}, "
+                    f"actual_length={actual_len})"
                 )
             else:
                 last_error = f"Slot {slot} could not be read from lock"

--- a/custom_components/staykey/services/providers/zwave.py
+++ b/custom_components/staykey/services/providers/zwave.py
@@ -1,11 +1,10 @@
-"""Z-Wave operations via HA's internal zwave_js integration.
+"""Z-Wave LockProvider.
 
-Accesses Z-Wave JS server through HA's zwave_js config entry runtime data
-to perform operations not exposed by the REST API (code slot reading,
-node interview status, etc).
-
-Uses zwave-js-server-python's lock utilities for active node queries
-when the passive ValueDB cache is unpopulated.
+Wraps the existing ``zwave_js`` services and the deep readback path that
+uses ``zwave-js-server-python`` directly to verify a code was actually
+programmed on the lock.  The implementation is unchanged from the
+pre-refactor ``services/zwave.py``; only the public surface is adapted
+to the protocol-agnostic types in :mod:`..lock_provider`.
 """
 
 from __future__ import annotations
@@ -17,13 +16,16 @@ from typing import Any, Dict, List, Optional
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from ..lock_provider import CapabilityInfo, LockProvider, ProviderResult, SlotInfo
+
 try:
-    from zwave_js_server.const import CommandClass
+    from zwave_js_server.const import CommandClass  # noqa: F401
     from zwave_js_server.util.lock import (
-        get_code_slots,
+        get_code_slots,  # noqa: F401  # kept for callers that still import it
         get_usercode_from_node,
         get_usercodes,
     )
+
     HAS_ZWAVE_LIB = True
 except ImportError:
     HAS_ZWAVE_LIB = False
@@ -31,45 +33,88 @@ except ImportError:
 LOGGER = logging.getLogger(__name__)
 
 
-def _get_zwave_client(hass: HomeAssistant) -> Optional[Any]:
-    """Retrieve the zwave_js client from HA's integration runtime data."""
-    try:
-        entries = hass.config_entries.async_entries("zwave_js")
-        for entry in entries:
-            if entry.state.name.lower() == "loaded":
-                runtime_data = getattr(entry, "runtime_data", None)
-                if runtime_data is None:
-                    continue
-                client = getattr(runtime_data, "client", None)
-                if client:
-                    return client
+class ZwaveLockProvider:
+    """LockProvider implementation for Z-Wave JS locks."""
 
-                if isinstance(runtime_data, dict):
-                    return runtime_data.get("client")
-    except Exception:
-        LOGGER.debug("Could not access zwave_js runtime data", exc_info=True)
-    return None
+    name: str = "zwave"
+
+    async def set_code(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        slot: int,
+        code: str,
+    ) -> ProviderResult:
+        """Set a code and verify by actively querying the slot from the lock."""
+        return await _set_and_verify_code(hass, entity_id, slot, str(code))
+
+    async def clear_code(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        slot: int,
+    ) -> ProviderResult:
+        """Clear a code slot via ``zwave_js.clear_lock_usercode``."""
+        await hass.services.async_call(
+            "zwave_js",
+            "clear_lock_usercode",
+            {"entity_id": entity_id, "code_slot": slot},
+            blocking=True,
+        )
+        return ProviderResult(slot=slot, method="zwave_clear", verified=True)
+
+    async def read_codes(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        max_slots: int = 30,
+    ) -> List[SlotInfo]:
+        """Read lock code-slot contents from the cached Z-Wave ValueDB."""
+        return await _read_code_slots(hass, entity_id, max_slots)
+
+    async def get_capabilities(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+    ) -> CapabilityInfo:
+        info = await get_node_info(hass, entity_id)
+        if not info:
+            return CapabilityInfo(supports_access_codes=False)
+
+        return CapabilityInfo(
+            supports_access_codes=bool(info.get("supports_user_codes")),
+            max_slots=info.get("max_code_slots"),
+            extra=info,
+        )
 
 
-def _get_zwave_node_for_entity(hass: HomeAssistant, entity_id: str) -> Optional[Any]:
+# ---------------------------------------------------------------------------
+# Internals (private to this provider)
+# ---------------------------------------------------------------------------
+
+
+def _get_zwave_node_for_entity(
+    hass: HomeAssistant, entity_id: str
+) -> Optional[Any]:
     """Look up the Z-Wave node associated with a HA entity via the device registry."""
     try:
         entity_reg = er.async_get(hass)
         entity_entry = entity_reg.async_get(entity_id)
         if not entity_entry or not entity_entry.device_id:
-            LOGGER.warning("Z-Wave lookup: no entity registry entry or device_id for %s", entity_id)
+            LOGGER.warning(
+                "Z-Wave lookup: no entity registry entry or device_id for %s",
+                entity_id,
+            )
             return None
 
         dev_reg = dr.async_get(hass)
         device = dev_reg.async_get(entity_entry.device_id)
         if not device:
-            LOGGER.warning("Z-Wave lookup: no device registry entry for device_id %s", entity_entry.device_id)
+            LOGGER.warning(
+                "Z-Wave lookup: no device registry entry for device_id %s",
+                entity_entry.device_id,
+            )
             return None
-
-        LOGGER.info(
-            "Z-Wave lookup: entity=%s device=%s identifiers=%s",
-            entity_id, device.name, device.identifiers,
-        )
 
         zwave_node_id = None
         for domain, identifier in device.identifiers:
@@ -79,22 +124,26 @@ def _get_zwave_node_for_entity(hass: HomeAssistant, entity_id: str) -> Optional[
                     try:
                         zwave_node_id = int(parts[1])
                     except ValueError:
-                        LOGGER.warning("Z-Wave lookup: could not parse node_id from %s", identifier)
+                        LOGGER.warning(
+                            "Z-Wave lookup: could not parse node_id from %s",
+                            identifier,
+                        )
                 break
 
         if zwave_node_id is None:
-            LOGGER.warning("Z-Wave lookup: no zwave_js identifier on device %s (identifiers=%s)", device.name, device.identifiers)
             return None
 
         entries = hass.config_entries.async_entries("zwave_js")
         for config_entry in entries:
-            state_name = config_entry.state.name if hasattr(config_entry.state, "name") else str(config_entry.state)
+            state_name = (
+                config_entry.state.name
+                if hasattr(config_entry.state, "name")
+                else str(config_entry.state)
+            )
             if state_name.lower() != "loaded":
-                LOGGER.info("Z-Wave lookup: skipping config entry (state=%s)", state_name)
                 continue
             runtime_data = getattr(config_entry, "runtime_data", None)
             if runtime_data is None:
-                LOGGER.warning("Z-Wave lookup: no runtime_data on loaded config entry")
                 continue
 
             client = getattr(runtime_data, "client", None)
@@ -103,50 +152,34 @@ def _get_zwave_node_for_entity(hass: HomeAssistant, entity_id: str) -> Optional[
             if client is None and hasattr(runtime_data, "driver"):
                 client = runtime_data
             if client is None:
-                LOGGER.warning(
-                    "Z-Wave lookup: no client in runtime_data (type=%s, attrs=%s)",
-                    type(runtime_data).__name__,
-                    [a for a in dir(runtime_data) if not a.startswith("_")][:15],
-                )
                 continue
 
             driver = getattr(client, "driver", None)
             if driver is None:
-                LOGGER.warning("Z-Wave lookup: no driver on client")
                 continue
 
             controller = getattr(driver, "controller", None)
             if controller is None:
-                LOGGER.warning("Z-Wave lookup: no controller on driver")
                 continue
 
             nodes = getattr(controller, "nodes", {})
-            node_keys = list(nodes.keys())[:10]
-            LOGGER.info(
-                "Z-Wave lookup: looking for node %d in %d nodes (keys=%s, key_types=%s)",
-                zwave_node_id, len(nodes), node_keys,
-                [type(k).__name__ for k in node_keys],
-            )
             if zwave_node_id in nodes:
                 return nodes[zwave_node_id]
             for key in nodes:
                 if str(key) == str(zwave_node_id):
-                    LOGGER.info("Z-Wave lookup: found node via string match (key=%r)", key)
                     return nodes[key]
 
-        LOGGER.warning("Z-Wave lookup: node %d not found in any loaded driver", zwave_node_id)
+        LOGGER.warning(
+            "Z-Wave lookup: node %d not found in any loaded driver", zwave_node_id
+        )
     except Exception:
         LOGGER.exception("Z-Wave lookup failed for entity %s", entity_id)
     return None
 
 
-async def read_code_slots(
+async def _read_code_slots(
     hass: HomeAssistant, entity_id: str, max_slots: int = 30
-) -> List[Dict[str, Any]]:
-    """Read lock code slot contents from the Z-Wave node.
-
-    Uses zwave-js-server-python's get_usercodes which reads from the ValueDB cache.
-    """
+) -> List[SlotInfo]:
     if not HAS_ZWAVE_LIB:
         LOGGER.warning("zwave_js_server library not available for code slot reading")
         return []
@@ -158,39 +191,31 @@ async def read_code_slots(
 
     try:
         lib_slots = get_usercodes(node)
-        results: List[Dict[str, Any]] = []
+        results: List[SlotInfo] = []
         for s in lib_slots:
             slot_num = s["code_slot"]
             if slot_num > max_slots:
                 continue
-            slot_info: Dict[str, Any] = {
-                "slot": slot_num,
-                "occupied": s.get("in_use") is True,
-            }
-            if s.get("in_use") and s.get("usercode"):
-                slot_info["code"] = str(s["usercode"])
-            results.append(slot_info)
+            occupied = s.get("in_use") is True
+            code: Optional[str] = None
+            if occupied and s.get("usercode"):
+                code = str(s["usercode"])
+            results.append(SlotInfo(slot=slot_num, occupied=occupied, code=code))
         return results
     except Exception:
         LOGGER.exception("Error reading code slots for %s", entity_id)
         return []
 
 
-async def fetch_code_slot(
+async def _fetch_code_slot(
     hass: HomeAssistant, entity_id: str, slot: int
 ) -> Optional[Dict[str, Any]]:
-    """Actively query a single code slot from the lock over Z-Wave.
-
-    Unlike read_code_slots (which reads from cache), this sends a Z-Wave command
-    to the lock to fetch the current slot value, populating the ValueDB.
-    """
+    """Actively query a single code slot from the lock over Z-Wave."""
     if not HAS_ZWAVE_LIB:
-        LOGGER.warning("zwave_js_server library not available for active code fetch")
         return None
 
     node = _get_zwave_node_for_entity(hass, entity_id)
     if not node:
-        LOGGER.warning("No Z-Wave node found for %s", entity_id)
         return None
 
     try:
@@ -208,7 +233,12 @@ async def fetch_code_slot(
 async def get_node_info(
     hass: HomeAssistant, entity_id: str
 ) -> Optional[Dict[str, Any]]:
-    """Get Z-Wave node information for capability discovery."""
+    """Get Z-Wave node information for capability discovery.
+
+    Public helper used by ``handlers/diagnostics.py`` and the legacy
+    capability fallback in ``handlers/capability.py``; returns ``None``
+    on Matter / Wi-Fi / Zigbee devices, which is fine.
+    """
     node = _get_zwave_node_for_entity(hass, entity_id)
     if not node:
         return None
@@ -231,10 +261,7 @@ async def get_node_info(
                 cc_name = getattr(value, "command_class_name", "")
                 if cc is not None and cc not in seen_ccs:
                     seen_ccs.add(cc)
-                    command_classes.append({
-                        "id": cc,
-                        "name": str(cc_name),
-                    })
+                    command_classes.append({"id": cc, "name": str(cc_name)})
 
         info["command_classes"] = command_classes
 
@@ -277,20 +304,20 @@ async def get_node_info(
         return None
 
 
-async def set_and_verify_code(
+async def _set_and_verify_code(
     hass: HomeAssistant,
     entity_id: str,
     slot: int,
     code: str,
     max_retries: int = 2,
     verify_delay_s: float = 2.0,
-) -> Dict[str, Any]:
+) -> ProviderResult:
     """Set a lock code and verify by actively querying the slot from the lock.
 
-    Uses node.async_invoke_cc_api to fetch the slot value directly from the lock
-    rather than relying on the passive ValueDB cache.
+    Uses node.async_invoke_cc_api to fetch the slot value directly from the
+    lock rather than relying on the passive ValueDB cache.
     """
-    last_error = None
+    last_error: Optional[str] = None
 
     for attempt in range(max_retries + 1):
         try:
@@ -307,16 +334,23 @@ async def set_and_verify_code(
 
             await asyncio.sleep(verify_delay_s)
 
-            result = await fetch_code_slot(hass, entity_id, slot)
-            if result and result.get("occupied") and result.get("code") == str(code):
-                return {
-                    "slot": slot,
-                    "verified": True,
-                    "method": "zwave_set_and_verify",
-                    "attempts": attempt + 1,
-                }
+            result = await _fetch_code_slot(hass, entity_id, slot)
+            if (
+                result
+                and result.get("occupied")
+                and result.get("code") == str(code)
+            ):
+                return ProviderResult(
+                    slot=slot,
+                    method="zwave_set_and_verify",
+                    verified=True,
+                    attempts=attempt + 1,
+                )
             elif result:
-                last_error = f"Slot {slot} readback mismatch: expected {code}, got {result.get('code')}"
+                last_error = (
+                    f"Slot {slot} readback mismatch: expected {code}, "
+                    f"got {result.get('code')}"
+                )
             else:
                 last_error = f"Slot {slot} could not be read from lock"
 
@@ -334,10 +368,10 @@ async def set_and_verify_code(
         if attempt < max_retries:
             await asyncio.sleep(1.0)
 
-    return {
-        "slot": slot,
-        "verified": False,
-        "method": "zwave_set_and_verify",
-        "attempts": max_retries + 1,
-        "error": last_error,
-    }
+    return ProviderResult(
+        slot=slot,
+        method="zwave_set_and_verify",
+        verified=False,
+        attempts=max_retries + 1,
+        error=last_error,
+    )

--- a/custom_components/staykey/state_filter.py
+++ b/custom_components/staykey/state_filter.py
@@ -1,7 +1,7 @@
 """State change filtering for Staykey gateway forwarding.
 
 Determines which HA state_changed events are meaningful enough to forward
-to the Staykey backend as activity entries. Filters out:
+as activity updates. Filters out:
 - Attribute-only changes (state string unchanged)
 - Transitional cover states (opening/closing)
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,91 @@
+"""Test configuration: stub Home Assistant modules.
+
+The Staykey integration is normally loaded inside a HA process where
+``homeassistant.*`` is available.  Our unit tests don't need a running
+HA instance and shouldn't pull the framework as a dev dependency, so we
+register lightweight stubs at import time.  Only the symbols actually
+referenced at module-import time need to exist; runtime calls into HA
+(e.g. ``hass.services.async_call``) belong in integration tests, not
+here.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+# Make ``custom_components/staykey`` importable as the package root for
+# tests, without going through HA's component loader.
+PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "custom_components" / "staykey"
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+
+def _ensure_module(dotted: str) -> types.ModuleType:
+    if dotted in sys.modules:
+        return sys.modules[dotted]
+
+    parts = dotted.split(".")
+    parent: types.ModuleType | None = None
+    accumulated = ""
+    for part in parts:
+        accumulated = f"{accumulated}.{part}" if accumulated else part
+        if accumulated not in sys.modules:
+            mod = types.ModuleType(accumulated)
+            sys.modules[accumulated] = mod
+            if parent is not None:
+                setattr(parent, part, mod)
+        parent = sys.modules[accumulated]
+
+    return sys.modules[dotted]
+
+
+_ensure_module("homeassistant")
+_ensure_module("homeassistant.core")
+_ensure_module("homeassistant.exceptions")
+_ensure_module("homeassistant.helpers")
+_ensure_module("homeassistant.helpers.device_registry")
+_ensure_module("homeassistant.helpers.entity_registry")
+
+
+# Minimal placeholders for symbols our modules import at top level.
+class _HomeAssistant:  # noqa: D401 - stub class
+    """Stand-in for ``homeassistant.core.HomeAssistant``."""
+
+
+sys.modules["homeassistant.core"].HomeAssistant = _HomeAssistant
+
+
+class _HomeAssistantError(Exception):
+    """Stand-in for ``homeassistant.exceptions.HomeAssistantError``.
+
+    Mirrors the real class's keyword-only ``translation_*`` attributes so
+    tests can construct exceptions the way HA's matter integration does.
+    """
+
+    def __init__(
+        self,
+        *args,
+        translation_domain=None,
+        translation_key=None,
+        translation_placeholders=None,
+        **kwargs,
+    ):
+        super().__init__(*args)
+        self.translation_domain = translation_domain
+        self.translation_key = translation_key
+        self.translation_placeholders = translation_placeholders
+
+
+sys.modules["homeassistant.exceptions"].HomeAssistantError = _HomeAssistantError
+
+
+def _async_get(_):  # noqa: D401 - stub function
+    """Stand-in for the HA registry async_get accessors."""
+    raise RuntimeError(
+        "homeassistant.helpers.*_registry.async_get is stubbed in tests"
+    )
+
+
+sys.modules["homeassistant.helpers.device_registry"].async_get = _async_get
+sys.modules["homeassistant.helpers.entity_registry"].async_get = _async_get

--- a/tests/test_event_tap.py
+++ b/tests/test_event_tap.py
@@ -1,0 +1,310 @@
+"""Tests for the ``tap_events`` passthrough.
+
+Covers the input coercion / clamping rules and the event-serialization
+path that turns HA's rich ``Event`` objects into JSON-friendly dicts.
+The actual ``hass.bus.async_listen`` -> sleep -> unsubscribe loop is
+exercised with a tiny fake bus to keep tests sync-free of a real HA
+runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+
+
+def _ev(event_type: str, data, origin="LOCAL", time_fired=None, ctx=None):
+    """Build a stand-in for ``homeassistant.core.Event`` for serializer tests."""
+    return SimpleNamespace(
+        event_type=event_type,
+        data=data,
+        origin=SimpleNamespace(value=origin) if isinstance(origin, str) else origin,
+        time_fired=time_fired or dt.datetime(2026, 5, 6, 5, 30, tzinfo=dt.timezone.utc),
+        context=ctx
+        or SimpleNamespace(id="ctx-1", user_id=None, parent_id=None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Input coercion
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_duration_defaults_when_missing():
+    from handlers.event_tap import _coerce_duration
+
+    assert _coerce_duration(None) == 10.0
+
+
+def test_coerce_duration_clamps_above_max():
+    from handlers.event_tap import _coerce_duration
+
+    # The max cap is 60s — anything larger should clamp, not reject.
+    assert _coerce_duration(600) == 60.0
+
+
+def test_coerce_duration_rejects_non_positive():
+    from handlers.event_tap import _coerce_duration
+
+    with pytest.raises(ValueError):
+        _coerce_duration(0)
+    with pytest.raises(ValueError):
+        _coerce_duration(-1)
+
+
+def test_coerce_duration_rejects_non_numeric():
+    from handlers.event_tap import _coerce_duration
+
+    with pytest.raises(ValueError):
+        _coerce_duration("forever")
+
+
+def test_coerce_max_events_defaults_when_missing():
+    from handlers.event_tap import _coerce_max_events
+
+    assert _coerce_max_events(None) == 200
+
+
+def test_coerce_max_events_clamps_to_hard_max():
+    from handlers.event_tap import _coerce_max_events
+
+    assert _coerce_max_events(10_000) == 500
+
+
+def test_coerce_max_events_rejects_bool_even_though_python_treats_it_as_int():
+    from handlers.event_tap import _coerce_max_events
+
+    # Catches the ``isinstance(True, int) is True`` footgun.
+    with pytest.raises(ValueError):
+        _coerce_max_events(True)
+
+
+def test_coerce_max_events_rejects_non_positive():
+    from handlers.event_tap import _coerce_max_events
+
+    with pytest.raises(ValueError):
+        _coerce_max_events(0)
+
+
+def test_coerce_event_types_returns_none_for_empty_or_missing():
+    from handlers.event_tap import _coerce_event_types
+
+    assert _coerce_event_types(None) is None
+    assert _coerce_event_types([]) is None
+
+
+def test_coerce_event_types_validates_entries():
+    from handlers.event_tap import _coerce_event_types
+
+    assert _coerce_event_types(["state_changed", "matter_event"]) == [
+        "state_changed",
+        "matter_event",
+    ]
+    with pytest.raises(ValueError):
+        _coerce_event_types([""])
+    with pytest.raises(ValueError):
+        _coerce_event_types([None])
+    with pytest.raises(ValueError):
+        _coerce_event_types("state_changed")  # not a list
+
+
+# ---------------------------------------------------------------------------
+# Event serialization
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_event_unwraps_primitives_and_metadata():
+    from handlers.event_tap import _serialize_event
+
+    payload = _serialize_event(
+        _ev(
+            "state_changed",
+            data={"entity_id": "lock.foo", "new_state": "locked"},
+        )
+    )
+    assert payload["event_type"] == "state_changed"
+    assert payload["origin"] == "LOCAL"
+    assert payload["data"] == {"entity_id": "lock.foo", "new_state": "locked"}
+    assert payload["context"] == {"id": "ctx-1", "user_id": None, "parent_id": None}
+    # Datetime is rendered as ISO 8601, UTC.
+    assert payload["time_fired"].startswith("2026-05-06T05:30:00")
+
+
+def test_serialize_event_handles_missing_optional_fields():
+    from handlers.event_tap import _serialize_event
+
+    payload = _serialize_event(
+        SimpleNamespace(
+            event_type="x",
+            data=None,
+            origin=None,
+            time_fired=None,
+            context=None,
+        )
+    )
+    assert payload == {
+        "event_type": "x",
+        "time_fired": None,
+        "origin": None,
+        "context": None,
+        "data": None,
+    }
+
+
+def test_make_serializable_unwraps_as_dict_objects():
+    from handlers.event_tap import _make_serializable
+
+    state_like = SimpleNamespace(
+        as_dict=lambda: {
+            "state": "unlocked",
+            "attributes": {"changed_by": "User 1"},
+            "last_changed": dt.datetime(2026, 5, 6, 5, 30, tzinfo=dt.timezone.utc),
+        }
+    )
+    out = _make_serializable({"new_state": state_like})
+    assert out == {
+        "new_state": {
+            "state": "unlocked",
+            "attributes": {"changed_by": "User 1"},
+            "last_changed": "2026-05-06T05:30:00+00:00",
+        }
+    }
+
+
+def test_make_serializable_falls_back_to_str_for_unknown_objects():
+    from handlers.event_tap import _make_serializable
+
+    class Weird:
+        def __repr__(self):
+            return "<weird>"
+
+    assert _make_serializable(Weird()) == "<weird>"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end loop with a fake bus
+# ---------------------------------------------------------------------------
+
+
+class _FakeBus:
+    """Minimal stand-in for ``hass.bus`` exposing async_listen."""
+
+    def __init__(self):
+        self._subs: dict = {}
+
+    def async_listen(self, event_type, callback):
+        self._subs.setdefault(event_type, []).append(callback)
+
+        def _unsub():
+            self._subs[event_type].remove(callback)
+
+        return _unsub
+
+    def fire(self, event):
+        for et in (event.event_type, "*"):
+            for cb in list(self._subs.get(et, [])):
+                cb(event)
+
+
+def test_tap_events_returns_captured_events_during_window(monkeypatch):
+    from handlers import event_tap
+
+    bus = _FakeBus()
+    hass = SimpleNamespace(bus=bus)
+
+    async def _run():
+        # Speed up the test: replace asyncio.sleep so we don't actually wait.
+        async def _instant_sleep(_seconds):
+            # Fire a couple of events synchronously while the listener
+            # is registered, then return.
+            bus.fire(_ev("state_changed", {"entity_id": "lock.foo"}))
+            bus.fire(_ev("matter_event", {"node_id": 1, "user_index": 1}))
+            bus.fire(_ev("state_changed", {"entity_id": "lock.bar"}))
+
+        monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+        return await event_tap.handle_tap_events(
+            hass,
+            None,
+            {"duration_seconds": 1, "max_events": 10},
+        )
+
+    out = asyncio.run(_run())
+    assert out["captured"] == 3
+    assert out["truncated"] is False
+    assert {e["event_type"] for e in out["events"]} == {
+        "state_changed",
+        "matter_event",
+    }
+
+
+def test_tap_events_filters_by_entity_id(monkeypatch):
+    from handlers import event_tap
+
+    bus = _FakeBus()
+    hass = SimpleNamespace(bus=bus)
+
+    async def _run():
+        async def _instant_sleep(_seconds):
+            bus.fire(_ev("state_changed", {"entity_id": "lock.foo"}))
+            bus.fire(_ev("state_changed", {"entity_id": "lock.bar"}))
+            bus.fire(_ev("state_changed", {"entity_id": "lock.foo"}))
+
+        monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+        return await event_tap.handle_tap_events(
+            hass,
+            None,
+            {
+                "event_types": ["state_changed"],
+                "entity_id": "lock.foo",
+                "duration_seconds": 1,
+            },
+        )
+
+    out = asyncio.run(_run())
+    assert out["captured"] == 2
+    assert all(e["data"]["entity_id"] == "lock.foo" for e in out["events"])
+
+
+def test_tap_events_truncates_at_max_events(monkeypatch):
+    from handlers import event_tap
+
+    bus = _FakeBus()
+    hass = SimpleNamespace(bus=bus)
+
+    async def _run():
+        async def _instant_sleep(_seconds):
+            for i in range(5):
+                bus.fire(_ev("state_changed", {"entity_id": f"lock.{i}"}))
+
+        monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+        return await event_tap.handle_tap_events(
+            hass,
+            None,
+            {"duration_seconds": 1, "max_events": 3},
+        )
+
+    out = asyncio.run(_run())
+    assert out["captured"] == 3
+    assert out["truncated"] is True
+
+
+def test_tap_events_subscribes_to_wildcard_when_event_types_omitted(monkeypatch):
+    from handlers import event_tap
+
+    bus = _FakeBus()
+    hass = SimpleNamespace(bus=bus)
+
+    async def _run():
+        async def _instant_sleep(_seconds):
+            bus.fire(_ev("anything_at_all", {"foo": "bar"}))
+
+        monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+        return await event_tap.handle_tap_events(hass, None, {"duration_seconds": 1})
+
+    out = asyncio.run(_run())
+    assert out["subscribed_event_types"] == "*"
+    assert out["captured"] == 1
+    assert out["events"][0]["event_type"] == "anything_at_all"

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -220,6 +220,38 @@ def test_matter_set_code_calls_only_set_lock_credential_on_happy_path():
     assert result.extra["credential_index"] == 7
 
 
+def test_matter_set_code_omits_user_status_and_sends_user_type():
+    """Bolt SE Add-rejection workaround: ``user_status`` must not be
+    sent on the wire and ``user_type`` must be sent explicitly as
+    ``unrestricted_user``.  See providers/matter.py moduledoc.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        {
+            "lock.front_door": {
+                "credential_index": 5,
+                "user_index": 5,
+                "next_credential_index": 6,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    _run(provider.set_code(hass, "lock.front_door", 5, "0000"))
+
+    set_call_data = hass.services.calls[0][2]
+    assert "user_status" not in set_call_data, (
+        "user_status must be omitted to avoid Bolt SE Add-rejection"
+    )
+    assert set_call_data.get("user_type") == "unrestricted_user", (
+        "user_type must be set explicitly to avoid Bolt SE Add-rejection"
+    )
+
+
 def test_matter_set_code_treats_duplicate_status_as_verified():
     from homeassistant.exceptions import HomeAssistantError
 
@@ -264,6 +296,36 @@ def test_matter_set_code_surfaces_non_duplicate_error_as_failure():
 
     assert result.verified is False
     assert "set_lock_credential" in (result.error or "")
+    assert result.extra.get("matter_status") == "occupied"
+    assert "matter_status=occupied" in (result.error or "")
+
+
+def test_matter_set_code_surfaces_unknown_im_status_in_extra_and_error():
+    """Reproduction of the Bolt SE rejection: HA renders IM-level
+    status codes as ``unknown(<int>)`` because they aren't in
+    ``SET_CREDENTIAL_STATUS_MAP``.  We must surface that verbatim so
+    Orion's activity log shows the actual lock status.
+    """
+    from homeassistant.exceptions import HomeAssistantError
+
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        HomeAssistantError(
+            "Failed to set credential: lock returned status `unknown(133)`.",
+            translation_placeholders={"status": "unknown(133)"},
+        ),
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 10, "5678"))
+
+    assert result.verified is False
+    assert result.extra.get("matter_status") == "unknown(133)"
+    assert "matter_status=unknown(133)" in (result.error or "")
 
 
 def test_matter_set_code_does_not_call_set_lock_user():

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -33,6 +33,8 @@ def test_capability_info_defaults():
 
     c = CapabilityInfo(supports_access_codes=True)
     assert c.max_slots is None
+    assert c.max_users is None
+    assert c.max_credentials_per_user is None
     assert c.extra == {}
 
 
@@ -481,6 +483,347 @@ def test_matter_set_code_marks_in_range_unknown_133_as_lock_rejected():
     assert result.extra.get("max_slots") == 10
     assert result.extra.get("slot") == 5
     assert "matter_status=unknown(133)" in (result.error or "")
+
+
+def test_matter_set_code_add_path_with_max_credentials_per_user_one_skips_user_index():
+    """Locks that report ``max_credentials_per_user`` of 1 (or omit the
+    field entirely) get the pre-stacking behaviour: no probe, ``user_index``
+    omitted on the wire, ``user_type`` set so the lock auto-allocates a
+    fresh user.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    _register_credential_status(hass, exists=False)
+    hass.services.register(
+        "matter",
+        "get_lock_info",
+        {
+            "lock.front_door": {
+                "supports_user_management": True,
+                "supported_credential_types": ["pin"],
+                "max_pin_users": 30,
+                "max_credentials_per_user": 1,
+            }
+        },
+    )
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        {
+            "lock.front_door": {
+                "credential_index": 3,
+                "user_index": 3,
+                "next_credential_index": 4,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    _run(provider.set_code(hass, "lock.front_door", 3, "1234"))
+
+    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
+    set_data = set_call[2]
+    assert "user_index" not in set_data
+    assert set_data.get("user_type") == "unrestricted_user"
+    # No additional credential_status probes beyond the preflight.
+    status_calls = [c for c in hass.services.calls if c[1] == "get_lock_credential_status"]
+    assert len(status_calls) == 1
+
+
+def test_matter_set_code_add_path_in_fresh_user_group_lets_lock_auto_allocate():
+    """Stacked lock (Bolt SE-style: ``max_credentials_per_user=5``).
+    First credential of a fresh user-group means no sibling is occupied,
+    so we fall back to the auto-allocate shape: ``user_index`` omitted,
+    ``user_type`` set.  Probes the other 4 slots in the group looking
+    for an occupant before deciding.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+
+    def _credential_status_stub(data):
+        # All probes return empty — fresh user-group.
+        return {
+            "lock.front_door": {
+                "credential_exists": False,
+                "user_index": None,
+                "next_credential_index": None,
+            }
+        }
+
+    hass.services.register(
+        "matter", "get_lock_credential_status", _credential_status_stub
+    )
+    hass.services.register(
+        "matter",
+        "get_lock_info",
+        {
+            "lock.front_door": {
+                "supports_user_management": True,
+                "supported_credential_types": ["pin"],
+                "max_pin_users": 10,
+                "max_credentials_per_user": 5,
+            }
+        },
+    )
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        {
+            "lock.front_door": {
+                "credential_index": 6,
+                "user_index": 2,  # lock auto-allocated
+                "next_credential_index": 7,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 6, "1234"))
+
+    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
+    set_data = set_call[2]
+    assert "user_index" not in set_data, (
+        "Fresh user-group must omit user_index so the lock auto-allocates"
+    )
+    assert set_data.get("user_type") == "unrestricted_user"
+
+    # Slot 6 + probes for slots 7, 8, 9, 10 = 5 credential_status calls
+    status_slots = [
+        c[2]["credential_index"]
+        for c in hass.services.calls
+        if c[1] == "get_lock_credential_status"
+    ]
+    assert sorted(status_slots) == [6, 7, 8, 9, 10]
+    assert result.verified is True
+    assert result.extra["user_index"] == 2
+
+
+def test_matter_set_code_add_path_in_existing_user_group_attaches_to_user():
+    """Stacked lock, second credential in a user-group: probe finds the
+    sibling slot already occupied with ``user_index=1``, so we send
+    ``user_index=1`` and **omit** ``user_type``/``user_status`` — this
+    is "Add credential to existing user", which the Bolt SE accepts.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+
+    def _credential_status_stub(data):
+        slot = data["credential_index"]
+        if slot == 1:
+            # sibling in the same user-group, already programmed
+            return {
+                "lock.front_door": {
+                    "credential_exists": True,
+                    "user_index": 1,
+                    "next_credential_index": 3,
+                }
+            }
+        return {
+            "lock.front_door": {
+                "credential_exists": False,
+                "user_index": None,
+                "next_credential_index": None,
+            }
+        }
+
+    hass.services.register(
+        "matter", "get_lock_credential_status", _credential_status_stub
+    )
+    hass.services.register(
+        "matter",
+        "get_lock_info",
+        {
+            "lock.front_door": {
+                "supports_user_management": True,
+                "supported_credential_types": ["pin"],
+                "max_pin_users": 10,
+                "max_credentials_per_user": 5,
+            }
+        },
+    )
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        {
+            "lock.front_door": {
+                "credential_index": 2,
+                "user_index": 1,  # attached to existing user
+                "next_credential_index": 3,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 2, "1234"))
+
+    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
+    set_data = set_call[2]
+    assert set_data.get("user_index") == 1, (
+        "Existing user-group: must send the discovered user_index"
+    )
+    assert "user_type" not in set_data, (
+        "Existing user-group: user_type/user_status must be null on the wire"
+    )
+    assert "user_status" not in set_data
+    assert result.verified is True
+    assert result.extra["operation"] == "add"
+    assert result.extra["user_index"] == 1
+
+
+def test_matter_set_code_stacking_short_circuits_on_first_occupied_sibling():
+    """The probe walks slots in order and stops at the first occupied
+    one — important for keeping the per-Add cost bounded by the first
+    occupant rather than always scanning the whole group.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+
+    def _credential_status_stub(data):
+        slot = data["credential_index"]
+        if slot == 1:
+            return {
+                "lock.front_door": {
+                    "credential_exists": True,
+                    "user_index": 7,
+                }
+            }
+        return {
+            "lock.front_door": {"credential_exists": False, "user_index": None}
+        }
+
+    hass.services.register(
+        "matter", "get_lock_credential_status", _credential_status_stub
+    )
+    hass.services.register(
+        "matter",
+        "get_lock_info",
+        {
+            "lock.front_door": {
+                "max_pin_users": 10,
+                "max_credentials_per_user": 5,
+            }
+        },
+    )
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        {"lock.front_door": {"credential_index": 5, "user_index": 7}},
+    )
+
+    provider = MatterLockProvider()
+    _run(provider.set_code(hass, "lock.front_door", 5, "1234"))
+
+    # Preflight (slot 5) + probe slot 1 (occupant found, stop).
+    status_slots = [
+        c[2]["credential_index"]
+        for c in hass.services.calls
+        if c[1] == "get_lock_credential_status"
+    ]
+    assert status_slots == [5, 1], (
+        "Probe must short-circuit at the first occupied sibling, not "
+        "scan all 4 remaining slots"
+    )
+
+
+def test_matter_modify_path_unaffected_by_stacking_capabilities():
+    """Modify path always uses the queried user_index regardless of
+    ``max_credentials_per_user`` — the credential already exists, no
+    user-group probing needed.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    _register_credential_status(hass, exists=True, user_index=42)
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        {"lock.front_door": {"credential_index": 7, "user_index": 42}},
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 7, "1234"))
+
+    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
+    set_data = set_call[2]
+    assert set_data["user_index"] == 42
+    assert "user_type" not in set_data
+
+    # Modify must NOT call get_lock_info (no need for stacking caps).
+    info_calls = [c for c in hass.services.calls if c[1] == "get_lock_info"]
+    assert info_calls == []
+    # And must NOT probe siblings.
+    status_calls = [
+        c for c in hass.services.calls if c[1] == "get_lock_credential_status"
+    ]
+    assert len(status_calls) == 1
+    assert result.extra["operation"] == "modify"
+
+
+def test_matter_get_capabilities_exposes_max_users_and_credentials_per_user():
+    """``get_capabilities`` must surface all three Matter capacity caps so
+    Orion's CapabilityLearner can persist them: ``max_users``,
+    ``max_credentials_per_user``, and the derived ``max_slots`` (their
+    product when stacking is supported).
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter",
+        "get_lock_info",
+        {
+            "lock.front_door": {
+                "supports_user_management": True,
+                "supported_credential_types": ["pin"],
+                "max_pin_users": 10,
+                "max_users": 10,
+                "max_credentials_per_user": 5,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    caps = _run(provider.get_capabilities(hass, "lock.front_door"))
+
+    assert caps.supports_access_codes is True
+    assert caps.max_users == 10
+    assert caps.max_credentials_per_user == 5
+    assert caps.max_slots == 50, (
+        "max_slots must be max_users * max_credentials_per_user when "
+        "stacking is supported (Bolt SE: 10 users × 5 PINs = 50 slots)"
+    )
+
+
+def test_matter_get_capabilities_falls_back_to_max_users_without_stacking():
+    """Locks that report ``max_credentials_per_user`` <= 1 (or omit it)
+    pre-stacking-style: ``max_slots`` equals ``max_users``.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter",
+        "get_lock_info",
+        {
+            "lock.front_door": {
+                "supports_user_management": True,
+                "supported_credential_types": ["pin"],
+                "max_pin_users": 250,
+                "max_credentials_per_user": 1,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    caps = _run(provider.get_capabilities(hass, "lock.front_door"))
+
+    assert caps.max_users == 250
+    assert caps.max_credentials_per_user == 1
+    assert caps.max_slots == 250
 
 
 def test_matter_set_code_does_not_call_set_lock_user():

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -76,20 +76,48 @@ def test_matter_extract_entity_response_handles_none():
 # ---------------------------------------------------------------------------
 
 
-def test_lock_supports_access_codes_matter_always_true():
+def test_lock_supports_access_codes_matter_requires_pin_signal():
+    """Matter locks must advertise PIN support via at least one of the
+    concrete signals before we claim ``supports_access_codes``.
+
+    A bare Matter lock with no PIN cluster (e.g. fingerprint-only)
+    must NOT show as supporting access codes — Matter integration
+    auto-registers ``set_lock_credential`` on every Matter lock so the
+    presence of the service is meaningless.
+    """
     from lock_capability_heuristics import lock_supports_access_codes
 
-    # Matter locks: trust the integration registration; supported_features
-    # bit 1 is set independently for unbolt support, not credentials.
-    assert lock_supports_access_codes({"supported_features": 0}, "matter") is True
-    assert lock_supports_access_codes({}, "matter") is True
+    assert (
+        lock_supports_access_codes(
+            {"supported_credential_types": ["pin"]}, "matter"
+        )
+        is True
+    )
+    assert lock_supports_access_codes({"max_pin_users": 10}, "matter") is True
+    assert lock_supports_access_codes({"max_users": 10}, "matter") is True
+    assert (
+        lock_supports_access_codes({"supports_user_management": True}, "matter")
+        is True
+    )
+
+    # Conservative default: no PIN signals -> no access codes.
+    assert lock_supports_access_codes({"supported_features": 1}, "matter") is False
+    assert lock_supports_access_codes({}, "matter") is False
+    assert (
+        lock_supports_access_codes({"supported_credential_types": ["fingerprint"]}, "matter")
+        is False
+    )
 
 
 def test_lock_supports_access_codes_zwave_uses_supported_features_bit():
     from lock_capability_heuristics import lock_supports_access_codes
 
-    assert lock_supports_access_codes({"supported_features": 1}, "zwave_js") is True
-    assert lock_supports_access_codes({"supported_features": 0}, "zwave_js") is False
+    # Runtime passes the normalized protocol string `"zwave"` (see
+    # ``handlers/device_discovery._infer_protocol`` — the
+    # ``zwave_js`` HA domain is normalized to the protocol name the
+    # Staykey cloud side expects before the heuristic runs).
+    assert lock_supports_access_codes({"supported_features": 1}, "zwave") is True
+    assert lock_supports_access_codes({"supported_features": 0}, "zwave") is False
 
 
 def test_lock_supports_access_codes_unknown_protocol_falls_back_to_heuristic():
@@ -213,23 +241,90 @@ def _register_credential_status(
     )
 
 
+def test_matter_set_code_fails_safe_when_preflight_unavailable():
+    """If ``get_lock_credential_status`` raises (HA returns an error or
+    transport fails), the provider must not guess slot occupancy.
+
+    Previously the preflight returned ``None`` on failure and
+    ``set_code`` treated ``None`` the same as "slot is empty",
+    silently taking the Add path even when the slot was actually
+    occupied. That produced double-programming and undefined-behaviour
+    on some firmware.
+
+    Now the provider must surface a verified=False ProviderResult with
+    a ``preflight_unavailable`` marker so upstream automation treats the
+    failure as definitive rather than burning retries.
+    """
+    from homeassistant.exceptions import HomeAssistantError
+
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter",
+        "get_lock_credential_status",
+        HomeAssistantError("matter integration timed out"),
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 7, "1234"))
+
+    # set_lock_credential MUST NOT be called when preflight is unknown.
+    assert not any(c[1] == "set_lock_credential" for c in hass.services.calls), (
+        "set_lock_credential called despite preflight being unavailable - "
+        "this would silently double-program an occupied slot"
+    )
+
+    assert result.verified is False
+    assert "preflight_unavailable" in (result.error or "")
+    assert result.extra.get("operation") == "preflight"
+    assert "preflight_error" in result.extra
+
+
+def test_matter_set_code_preflight_none_payload_takes_add_path():
+    """HA may return a value that extracts to ``None`` (no per-entity dict).
+    That is distinct from :exc:`PreflightUnavailable` (the service call threw)
+    and must still choose the Add path (empty slot).
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter", "get_lock_credential_status", lambda _data: None
+    )
+
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        {
+            "lock.front_door": {
+                "credential_index": 7,
+                "user_index": 42,
+                "next_credential_index": 8,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 7, "1234"))
+
+    assert result.verified is True
+    assert any(c[1] == "set_lock_credential" for c in hass.services.calls)
+
+
 def test_matter_set_code_add_path_passes_user_type_and_omits_user_index():
-    """Bolt SE-compatible Add path (slot empty):
+    """Add path (slot empty) matches HA Matter Lock Manager UI:
 
     * ``credential_index`` = our slot
     * ``user_index`` is **not** sent (null on the wire) so the lock
       auto-allocates a fresh user.
     * ``user_type`` = ``unrestricted_user`` describes that new user.
-    * ``user_status`` is **not** sent — null on the wire.  The HA
-      Matter Lock Manager UI omits it (verified empirically against
-      a real Bolt SE via tap_events capture), and a previous revision
-      that sent ``occupied_enabled`` on this path caused the Bolt SE
-      to write the credential but leave the user in a state where the
-      keypad refused every PIN, even though SetCredential reported
-      ``kSuccess``.
+    * ``user_status`` is **not** sent — null on the wire. The UI omits
+      it, and sending ``occupied_enabled`` here has been observed on some
+      firmware to leave a credential written while the keypad rejects PINs.
 
-    This is the shape the HA Matter Lock Manager UI uses and the only
-    one Bolt SE accepts on Add.
+    This is the payload shape the Matter Lock Manager UI uses and what we
+    mirror for broad compatibility.
     """
     from services.providers.matter import MatterLockProvider
 
@@ -260,13 +355,13 @@ def test_matter_set_code_add_path_passes_user_type_and_omits_user_index():
     )
     assert "user_index" not in set_data, (
         "Add path must omit user_index (null on the wire) so the lock "
-        "auto-allocates a fresh user — Bolt SE rejects Add when "
+        "auto-allocates a fresh user — many Matter locks reject Add when "
         "userIndex is non-null and refers to a missing user"
     )
     assert "user_status" not in set_data, (
-        "Add path must omit user_status — sending it (any value) on "
-        "the Bolt SE produces a written-but-keypad-rejecting user; "
-        "the HA Matter Lock Manager UI also omits it"
+        "Add path must omit user_status — some firmware produces a "
+        "written-but-keypad-rejecting user if it is set; the HA Matter "
+        "Lock Manager UI also omits it"
     )
 
     assert result.verified is True
@@ -372,10 +467,9 @@ def test_matter_set_code_surfaces_non_duplicate_error_as_failure():
 
 
 def test_matter_set_code_surfaces_unknown_im_status_in_extra_and_error():
-    """Reproduction of the Bolt SE rejection: HA renders IM-level
-    status codes as ``unknown(<int>)`` because they aren't in
-    ``SET_CREDENTIAL_STATUS_MAP``.  We must surface that verbatim so
-    Orion's activity log shows the actual lock status.
+    """HA renders some IM-level Matter statuses as ``unknown(<int>)`` when
+    they are not in ``SET_CREDENTIAL_STATUS_MAP``. That value must appear
+    in ``extra`` and in the error string for operators.
     """
     from homeassistant.exceptions import HomeAssistantError
 
@@ -405,8 +499,7 @@ def test_matter_set_code_classifies_unknown_133_as_slot_out_of_range():
     """When ``unknown(133)`` comes back on Add and the lock advertises
     ``max_pin_users < requested slot``, the failure is reclassified as
     ``slot_out_of_range`` so callers see *why* the lock rejected the
-    call.  This is the empirically-observed Bolt SE failure mode for
-    slot 11 with 10 PIN slots.
+    call (e.g. requesting slot 11 when only 10 PIN credentials exist).
     """
     from homeassistant.exceptions import HomeAssistantError
 
@@ -495,11 +588,10 @@ def test_matter_get_capabilities_reports_max_slots_from_max_pin_users():
     ``max_pin_users`` (preferred) or ``max_users`` (fallback).
 
     We size ``max_slots`` conservatively at the lock's user count even
-    when ``max_credentials_per_user >= 2`` — vendor firmware (Ultraloq
-    Bolt SE) caps global PIN credentials at the user count regardless
-    of the spec's implied ``U × C`` ceiling.  Catalogued locks that
-    genuinely support the full product can override via
-    ``SupportedDevice.default_settings`` in Orion.
+    when ``max_credentials_per_user >= 2`` — much vendor firmware caps
+    global PIN credentials at the user count regardless of the spec's
+    implied ``U × C`` ceiling. Hosts with unusual hardware can correct
+    capacity in the Staykey supported-device catalog if needed.
     """
     from services.providers.matter import MatterLockProvider
 
@@ -524,8 +616,7 @@ def test_matter_get_capabilities_reports_max_slots_from_max_pin_users():
     assert caps.supports_access_codes is True
     assert caps.max_slots == 10, (
         "max_slots must be conservative (== max_pin_users) because "
-        "vendor firmware caps global PIN credentials at the user count "
-        "in practice (Bolt SE)"
+        "vendor firmware often caps global PIN credentials at the user count"
     )
 
 
@@ -611,8 +702,8 @@ def test_matter_clear_code_uses_user_index_from_credential_status():
 
 
 def test_matter_clear_code_returns_verified_no_op_when_already_empty():
-    """Important for Oban retries — clearing an already-empty slot
-    must not surface as a failure.
+    """Clearing an already-empty slot must succeed (idempotent) so retries
+    do not flap as hard failures.
     """
     from services.providers.matter import MatterLockProvider
 

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -33,8 +33,6 @@ def test_capability_info_defaults():
 
     c = CapabilityInfo(supports_access_codes=True)
     assert c.max_slots is None
-    assert c.max_users is None
-    assert c.max_credentials_per_user is None
     assert c.extra == {}
 
 
@@ -492,19 +490,16 @@ def test_matter_set_code_marks_in_range_unknown_133_as_lock_rejected():
     assert "matter_status=unknown(133)" in (result.error or "")
 
 
-def test_matter_get_capabilities_exposes_max_users_and_credentials_per_user():
-    """``get_capabilities`` must surface all three Matter capacity caps so
-    Orion's CapabilityLearner can persist them as telemetry:
-    ``max_users``, ``max_credentials_per_user``, and the derived
-    ``max_slots``.
+def test_matter_get_capabilities_reports_max_slots_from_max_pin_users():
+    """``get_capabilities`` reports ``max_slots`` equal to the lock's
+    ``max_pin_users`` (preferred) or ``max_users`` (fallback).
 
-    ``max_slots`` is conservative — equal to ``max_users`` even when
-    the lock advertises ``max_credentials_per_user >= 2`` — because
-    real-world firmware (Ultraloq Bolt SE) caps global PIN credentials
-    at the user count regardless of the spec's implied ``U × C``
-    ceiling.  Catalogued locks that genuinely support the full
-    product can override via ``SupportedDevice.default_settings`` in
-    Orion.
+    We size ``max_slots`` conservatively at the lock's user count even
+    when ``max_credentials_per_user >= 2`` — vendor firmware (Ultraloq
+    Bolt SE) caps global PIN credentials at the user count regardless
+    of the spec's implied ``U × C`` ceiling.  Catalogued locks that
+    genuinely support the full product can override via
+    ``SupportedDevice.default_settings`` in Orion.
     """
     from services.providers.matter import MatterLockProvider
 
@@ -527,19 +522,15 @@ def test_matter_get_capabilities_exposes_max_users_and_credentials_per_user():
     caps = _run(provider.get_capabilities(hass, "lock.front_door"))
 
     assert caps.supports_access_codes is True
-    assert caps.max_users == 10
-    assert caps.max_credentials_per_user == 5
     assert caps.max_slots == 10, (
-        "max_slots must be conservative (== max_users) because vendor "
-        "firmware caps global PIN credentials at max_users in practice "
-        "(Bolt SE)"
+        "max_slots must be conservative (== max_pin_users) because "
+        "vendor firmware caps global PIN credentials at the user count "
+        "in practice (Bolt SE)"
     )
 
 
-def test_matter_get_capabilities_falls_back_to_max_users_when_per_user_cap_is_one():
-    """Locks that report ``max_credentials_per_user`` of 1 (or omit it)
-    still report ``max_slots`` equal to ``max_users``.
-    """
+def test_matter_get_capabilities_falls_back_to_max_users_when_max_pin_users_missing():
+    """When ``max_pin_users`` is absent, fall back to ``max_users``."""
     from services.providers.matter import MatterLockProvider
 
     hass = _FakeHass()
@@ -550,8 +541,7 @@ def test_matter_get_capabilities_falls_back_to_max_users_when_per_user_cap_is_on
             "lock.front_door": {
                 "supports_user_management": True,
                 "supported_credential_types": ["pin"],
-                "max_pin_users": 250,
-                "max_credentials_per_user": 1,
+                "max_users": 250,
             }
         },
     )
@@ -559,8 +549,6 @@ def test_matter_get_capabilities_falls_back_to_max_users_when_per_user_cap_is_on
     provider = MatterLockProvider()
     caps = _run(provider.get_capabilities(hass, "lock.front_door"))
 
-    assert caps.max_users == 250
-    assert caps.max_credentials_per_user == 1
     assert caps.max_slots == 250
 
 

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -220,10 +220,15 @@ def test_matter_set_code_calls_only_set_lock_credential_on_happy_path():
     assert result.extra["credential_index"] == 7
 
 
-def test_matter_set_code_omits_user_status_and_sends_user_type():
-    """Bolt SE Add-rejection workaround: ``user_status`` must not be
-    sent on the wire and ``user_type`` must be sent explicitly as
-    ``unrestricted_user``.  See providers/matter.py moduledoc.
+def test_matter_set_code_omits_user_status_and_user_type():
+    """Per Matter spec 5.2.4.40 / chip SDK validity check, both
+    ``userStatus`` and ``userType`` MUST be null when ``userIndex`` is
+    non-null on Add or Modify.  Sending either causes the SDK to reject
+    with ``DlStatus::kInvalidField`` → IM ``InvalidCommand`` (0x85),
+    which HA renders as ``unknown(133)``.
+
+    This test guards against any regression that re-introduces either
+    field; see providers/matter.py moduledoc for the full background.
     """
     from services.providers.matter import MatterLockProvider
 
@@ -245,10 +250,14 @@ def test_matter_set_code_omits_user_status_and_sends_user_type():
 
     set_call_data = hass.services.calls[0][2]
     assert "user_status" not in set_call_data, (
-        "user_status must be omitted to avoid Bolt SE Add-rejection"
+        "user_status must be omitted; the lock auto-defaults to "
+        "kOccupiedEnabled per Matter spec"
     )
-    assert set_call_data.get("user_type") == "unrestricted_user", (
-        "user_type must be set explicitly to avoid Bolt SE Add-rejection"
+    assert "user_type" not in set_call_data, (
+        "user_type must be omitted; the lock auto-defaults to "
+        "kUnrestrictedUser per Matter spec.  Setting either field with "
+        "userIndex non-null causes the chip SDK to return "
+        "DlStatus::kInvalidField (IM 0x85 = 133)."
     )
 
 

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -766,8 +766,14 @@ def test_matter_modify_path_unaffected_by_stacking_capabilities():
 def test_matter_get_capabilities_exposes_max_users_and_credentials_per_user():
     """``get_capabilities`` must surface all three Matter capacity caps so
     Orion's CapabilityLearner can persist them: ``max_users``,
-    ``max_credentials_per_user``, and the derived ``max_slots`` (their
-    product when stacking is supported).
+    ``max_credentials_per_user``, and the derived ``max_slots``.
+
+    ``max_slots`` is conservative — equal to ``max_users`` even when
+    the lock advertises ``max_credentials_per_user >= 2`` — because
+    real-world firmware (Ultraloq Bolt SE) caps global credentials at
+    the user count regardless of the spec's implied ``U × C`` ceiling.
+    Catalogued locks that genuinely support the full product can
+    override via ``SupportedDevice.default_settings`` in Orion.
     """
     from services.providers.matter import MatterLockProvider
 
@@ -792,9 +798,12 @@ def test_matter_get_capabilities_exposes_max_users_and_credentials_per_user():
     assert caps.supports_access_codes is True
     assert caps.max_users == 10
     assert caps.max_credentials_per_user == 5
-    assert caps.max_slots == 50, (
-        "max_slots must be max_users * max_credentials_per_user when "
-        "stacking is supported (Bolt SE: 10 users × 5 PINs = 50 slots)"
+    assert caps.max_slots == 10, (
+        "max_slots must be conservative (== max_users) — the "
+        "max_credentials_per_user cap is consumed by the user-stacking "
+        "branch in set_code, not multiplied into max_slots, because "
+        "vendor firmware caps global PIN credentials at max_users in "
+        "practice (Bolt SE)"
     )
 
 

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -222,8 +222,11 @@ def test_matter_set_code_add_path_passes_user_type_and_omits_user_index():
     * ``user_index`` is **not** sent (null on the wire) so the lock
       auto-allocates a fresh user.
     * ``user_type`` = ``unrestricted_user`` describes that new user.
-    * ``user_status`` is **not** sent (lock defaults to
-      ``kOccupiedEnabled``).
+    * ``user_status`` = ``occupied_enabled`` enables the user
+      immediately.  Mirrors HA's ``set_lock_user`` defaults — without
+      this the Bolt SE writes the credential but leaves the user
+      disabled, so the keypad rejects every PIN even though
+      SetCredential returned ``kSuccess``.
 
     This is the shape the HA Matter Lock Manager UI uses and the only
     one Bolt SE accepts on Add.
@@ -260,8 +263,10 @@ def test_matter_set_code_add_path_passes_user_type_and_omits_user_index():
         "auto-allocates a fresh user — Bolt SE rejects Add when "
         "userIndex is non-null and refers to a missing user"
     )
-    assert "user_status" not in set_data, (
-        "user_status must be omitted; the lock defaults to kOccupiedEnabled"
+    assert set_data.get("user_status") == "occupied_enabled", (
+        "Add path must send user_status=occupied_enabled — without it "
+        "Bolt SE leaves the auto-created user disabled and the keypad "
+        "rejects every PIN, even though SetCredential reports success"
     )
 
     assert result.verified is True
@@ -526,6 +531,7 @@ def test_matter_set_code_add_path_with_max_credentials_per_user_one_skips_user_i
     set_data = set_call[2]
     assert "user_index" not in set_data
     assert set_data.get("user_type") == "unrestricted_user"
+    assert set_data.get("user_status") == "occupied_enabled"
     # No additional credential_status probes beyond the preflight.
     status_calls = [c for c in hass.services.calls if c[1] == "get_lock_credential_status"]
     assert len(status_calls) == 1
@@ -588,6 +594,7 @@ def test_matter_set_code_add_path_in_fresh_user_group_lets_lock_auto_allocate():
         "Fresh user-group must omit user_index so the lock auto-allocates"
     )
     assert set_data.get("user_type") == "unrestricted_user"
+    assert set_data.get("user_status") == "occupied_enabled"
 
     # Slot 6 + probes for slots 7, 8, 9, 10 = 5 credential_status calls
     status_slots = [

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -188,17 +188,55 @@ def _run(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
-def test_matter_set_code_calls_only_set_lock_credential_on_happy_path():
+def _register_credential_status(
+    hass: _FakeHass,
+    *,
+    entity_id: str = "lock.front_door",
+    exists: bool,
+    user_index: int | None = None,
+) -> None:
+    """Pre-register a ``matter.get_lock_credential_status`` response.
+
+    The provider always pre-flights the slot to choose Add vs Modify;
+    every set_code / clear_code test needs this stub registered.
+    """
+    hass.services.register(
+        "matter",
+        "get_lock_credential_status",
+        {
+            entity_id: {
+                "credential_exists": exists,
+                "user_index": user_index,
+                "next_credential_index": None,
+            }
+        },
+    )
+
+
+def test_matter_set_code_add_path_passes_user_type_and_omits_user_index():
+    """Bolt SE-compatible Add path (slot empty):
+
+    * ``credential_index`` = our slot
+    * ``user_index`` is **not** sent (null on the wire) so the lock
+      auto-allocates a fresh user.
+    * ``user_type`` = ``unrestricted_user`` describes that new user.
+    * ``user_status`` is **not** sent (lock defaults to
+      ``kOccupiedEnabled``).
+
+    This is the shape the HA Matter Lock Manager UI uses and the only
+    one Bolt SE accepts on Add.
+    """
     from services.providers.matter import MatterLockProvider
 
     hass = _FakeHass()
+    _register_credential_status(hass, exists=False)
     hass.services.register(
         "matter",
         "set_lock_credential",
         {
             "lock.front_door": {
                 "credential_index": 7,
-                "user_index": 7,
+                "user_index": 42,  # lock-allocated, not == slot
                 "next_credential_index": 8,
             }
         },
@@ -207,58 +245,73 @@ def test_matter_set_code_calls_only_set_lock_credential_on_happy_path():
     provider = MatterLockProvider()
     result = _run(provider.set_code(hass, "lock.front_door", 7, "1234"))
 
-    assert [(d, s) for d, s, _ in hass.services.calls] == [
-        ("matter", "set_lock_credential")
-    ]
-    set_call_data = hass.services.calls[0][2]
-    assert set_call_data["credential_index"] == 7
-    assert set_call_data["user_index"] == 7
-    assert set_call_data["credential_data"] == "1234"
+    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
+    set_data = set_call[2]
+    assert set_data["credential_index"] == 7
+    assert set_data["credential_data"] == "1234"
+    assert set_data.get("user_type") == "unrestricted_user", (
+        "Add path must send user_type so the lock auto-creates a "
+        "non-restricted user"
+    )
+    assert "user_index" not in set_data, (
+        "Add path must omit user_index (null on the wire) so the lock "
+        "auto-allocates a fresh user — Bolt SE rejects Add when "
+        "userIndex is non-null and refers to a missing user"
+    )
+    assert "user_status" not in set_data, (
+        "user_status must be omitted; the lock defaults to kOccupiedEnabled"
+    )
 
     assert result.verified is True
     assert result.method == "matter_set_credential"
-    assert result.extra["credential_index"] == 7
+    assert result.extra["operation"] == "add"
+    assert result.extra["user_index"] == 42
 
 
-def test_matter_set_code_omits_user_status_and_user_type():
-    """Per Matter spec 5.2.4.40 / chip SDK validity check, both
-    ``userStatus`` and ``userType`` MUST be null when ``userIndex`` is
-    non-null on Add or Modify.  Sending either causes the SDK to reject
-    with ``DlStatus::kInvalidField`` → IM ``InvalidCommand`` (0x85),
-    which HA renders as ``unknown(133)``.
+def test_matter_set_code_modify_path_passes_existing_user_index_and_omits_user_type():
+    """Modify path (slot occupied):
 
-    This test guards against any regression that re-introduces either
-    field; see providers/matter.py moduledoc for the full background.
+    * ``credential_index`` = our slot
+    * ``user_index`` = the existing user pulled from
+      ``get_lock_credential_status`` (so the lock keeps the existing
+      user-credential relationship).
+    * ``user_type`` and ``user_status`` are **both** omitted — chip
+      SDK validity check requires them null when userIndex is non-null
+      on Modify; sending either yields ``InvalidField`` → 0x85.
     """
     from services.providers.matter import MatterLockProvider
 
     hass = _FakeHass()
+    _register_credential_status(hass, exists=True, user_index=42)
     hass.services.register(
         "matter",
         "set_lock_credential",
         {
             "lock.front_door": {
-                "credential_index": 5,
-                "user_index": 5,
-                "next_credential_index": 6,
+                "credential_index": 7,
+                "user_index": 42,
+                "next_credential_index": 8,
             }
         },
     )
 
     provider = MatterLockProvider()
-    _run(provider.set_code(hass, "lock.front_door", 5, "0000"))
+    result = _run(provider.set_code(hass, "lock.front_door", 7, "1234"))
 
-    set_call_data = hass.services.calls[0][2]
-    assert "user_status" not in set_call_data, (
-        "user_status must be omitted; the lock auto-defaults to "
-        "kOccupiedEnabled per Matter spec"
+    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
+    set_data = set_call[2]
+    assert set_data["credential_index"] == 7
+    assert set_data["user_index"] == 42, (
+        "Modify path must send the existing user_index from "
+        "get_lock_credential_status"
     )
-    assert "user_type" not in set_call_data, (
-        "user_type must be omitted; the lock auto-defaults to "
-        "kUnrestrictedUser per Matter spec.  Setting either field with "
-        "userIndex non-null causes the chip SDK to return "
-        "DlStatus::kInvalidField (IM 0x85 = 133)."
+    assert "user_type" not in set_data, (
+        "user_type must be omitted on Modify; chip SDK validity check "
+        "rejects with InvalidField → 0x85 if non-null"
     )
+    assert "user_status" not in set_data
+    assert result.verified is True
+    assert result.extra["operation"] == "modify"
 
 
 def test_matter_set_code_treats_duplicate_status_as_verified():
@@ -267,6 +320,7 @@ def test_matter_set_code_treats_duplicate_status_as_verified():
     from services.providers.matter import MatterLockProvider
 
     hass = _FakeHass()
+    _register_credential_status(hass, exists=False)
     hass.services.register(
         "matter",
         "set_lock_credential",
@@ -291,6 +345,7 @@ def test_matter_set_code_surfaces_non_duplicate_error_as_failure():
     from services.providers.matter import MatterLockProvider
 
     hass = _FakeHass()
+    _register_credential_status(hass, exists=False)
     hass.services.register(
         "matter",
         "set_lock_credential",
@@ -320,6 +375,7 @@ def test_matter_set_code_surfaces_unknown_im_status_in_extra_and_error():
     from services.providers.matter import MatterLockProvider
 
     hass = _FakeHass()
+    _register_credential_status(hass, exists=False)
     hass.services.register(
         "matter",
         "set_lock_credential",
@@ -338,19 +394,22 @@ def test_matter_set_code_surfaces_unknown_im_status_in_extra_and_error():
 
 
 def test_matter_set_code_does_not_call_set_lock_user():
-    """Regression guard: dropping ``set_lock_user`` is what unblocked
-    the Bolt SE; this test fails loudly if anyone reintroduces it.
+    """Regression guard: ``set_lock_user`` is structurally hostile to
+    slot-based callers (raises UserSlotEmptyError on caller-supplied
+    indices for empty slots).  We always go through
+    ``set_lock_credential`` for both Add and Modify.
     """
     from services.providers.matter import MatterLockProvider
 
     hass = _FakeHass()
+    _register_credential_status(hass, exists=False)
     hass.services.register(
         "matter",
         "set_lock_credential",
         {
             "lock.front_door": {
                 "credential_index": 1,
-                "user_index": 1,
+                "user_index": 99,
                 "next_credential_index": 2,
             }
         },
@@ -361,3 +420,76 @@ def test_matter_set_code_does_not_call_set_lock_user():
 
     services_called = {(d, s) for d, s, _ in hass.services.calls}
     assert ("matter", "set_lock_user") not in services_called
+
+
+# ---------------------------------------------------------------------------
+# Matter provider — clear_code (looks up user_index, then ClearUser)
+# ---------------------------------------------------------------------------
+
+
+def test_matter_clear_code_uses_user_index_from_credential_status():
+    """``clear_code`` must read the user_index back from the lock,
+    *not* assume slot == user_index, because the Add path leaves the
+    user_index lock-allocated.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    _register_credential_status(hass, exists=True, user_index=42)
+    hass.services.register("matter", "clear_lock_user", {})
+
+    provider = MatterLockProvider()
+    result = _run(provider.clear_code(hass, "lock.front_door", 7))
+
+    clear_call = next(c for c in hass.services.calls if c[1] == "clear_lock_user")
+    assert clear_call[2]["user_index"] == 42, (
+        "ClearUser must use the existing user_index from "
+        "get_lock_credential_status, not the slot number"
+    )
+    assert result.verified is True
+    assert result.method == "matter_clear_user"
+    assert result.extra["user_index"] == 42
+
+
+def test_matter_clear_code_returns_verified_no_op_when_already_empty():
+    """Important for Oban retries — clearing an already-empty slot
+    must not surface as a failure.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    _register_credential_status(hass, exists=False)
+
+    provider = MatterLockProvider()
+    result = _run(provider.clear_code(hass, "lock.front_door", 7))
+
+    services_called = {s for _, s, _ in hass.services.calls}
+    assert "clear_lock_user" not in services_called, (
+        "Already-empty slot must not call clear_lock_user"
+    )
+    assert result.verified is True
+    assert result.method == "matter_clear_already_empty"
+
+
+def test_matter_clear_code_falls_back_to_clear_credential_for_orphan():
+    """Defensive: a credential that exists with no associated
+    user_index is an orphan (shouldn't happen via our own writes).
+    Fall back to clear_lock_credential which removes just the cred.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    _register_credential_status(hass, exists=True, user_index=None)
+    hass.services.register("matter", "clear_lock_credential", {})
+
+    provider = MatterLockProvider()
+    result = _run(provider.clear_code(hass, "lock.front_door", 7))
+
+    clear_call = next(
+        c for c in hass.services.calls if c[1] == "clear_lock_credential"
+    )
+    assert clear_call[2]["credential_index"] == 7
+    assert clear_call[2]["credential_type"] == "pin"
+    assert result.verified is True
+    assert result.method == "matter_clear_credential"
+    assert result.extra.get("orphan") is True

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -222,11 +222,13 @@ def test_matter_set_code_add_path_passes_user_type_and_omits_user_index():
     * ``user_index`` is **not** sent (null on the wire) so the lock
       auto-allocates a fresh user.
     * ``user_type`` = ``unrestricted_user`` describes that new user.
-    * ``user_status`` = ``occupied_enabled`` enables the user
-      immediately.  Mirrors HA's ``set_lock_user`` defaults — without
-      this the Bolt SE writes the credential but leaves the user
-      disabled, so the keypad rejects every PIN even though
-      SetCredential returned ``kSuccess``.
+    * ``user_status`` is **not** sent — null on the wire.  The HA
+      Matter Lock Manager UI omits it (verified empirically against
+      a real Bolt SE via tap_events capture), and a previous revision
+      that sent ``occupied_enabled`` on this path caused the Bolt SE
+      to write the credential but leave the user in a state where the
+      keypad refused every PIN, even though SetCredential reported
+      ``kSuccess``.
 
     This is the shape the HA Matter Lock Manager UI uses and the only
     one Bolt SE accepts on Add.
@@ -263,10 +265,10 @@ def test_matter_set_code_add_path_passes_user_type_and_omits_user_index():
         "auto-allocates a fresh user — Bolt SE rejects Add when "
         "userIndex is non-null and refers to a missing user"
     )
-    assert set_data.get("user_status") == "occupied_enabled", (
-        "Add path must send user_status=occupied_enabled — without it "
-        "Bolt SE leaves the auto-created user disabled and the keypad "
-        "rejects every PIN, even though SetCredential reports success"
+    assert "user_status" not in set_data, (
+        "Add path must omit user_status — sending it (any value) on "
+        "the Bolt SE produces a written-but-keypad-rejecting user; "
+        "the HA Matter Lock Manager UI also omits it"
     )
 
     assert result.verified is True
@@ -531,7 +533,7 @@ def test_matter_set_code_add_path_with_max_credentials_per_user_one_skips_user_i
     set_data = set_call[2]
     assert "user_index" not in set_data
     assert set_data.get("user_type") == "unrestricted_user"
-    assert set_data.get("user_status") == "occupied_enabled"
+    assert "user_status" not in set_data
     # No additional credential_status probes beyond the preflight.
     status_calls = [c for c in hass.services.calls if c[1] == "get_lock_credential_status"]
     assert len(status_calls) == 1
@@ -594,7 +596,7 @@ def test_matter_set_code_add_path_in_fresh_user_group_lets_lock_auto_allocate():
         "Fresh user-group must omit user_index so the lock auto-allocates"
     )
     assert set_data.get("user_type") == "unrestricted_user"
-    assert set_data.get("user_status") == "occupied_enabled"
+    assert "user_status" not in set_data
 
     # Slot 6 + probes for slots 7, 8, 9, 10 = 5 credential_status calls
     status_slots = [

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -390,6 +390,96 @@ def test_matter_set_code_surfaces_unknown_im_status_in_extra_and_error():
 
     assert result.verified is False
     assert result.extra.get("matter_status") == "unknown(133)"
+    # Without get_lock_info registered we fall back to raw matter_status
+    assert "matter_status=unknown(133)" in (result.error or "")
+
+
+def test_matter_set_code_classifies_unknown_133_as_slot_out_of_range():
+    """When ``unknown(133)`` comes back on Add and the lock advertises
+    ``max_pin_users < requested slot``, the failure is reclassified as
+    ``slot_out_of_range`` so callers see *why* the lock rejected the
+    call.  This is the empirically-observed Bolt SE failure mode for
+    slot 11 with 10 PIN slots.
+    """
+    from homeassistant.exceptions import HomeAssistantError
+
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    _register_credential_status(hass, exists=False)
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        HomeAssistantError(
+            "Failed to set credential: lock returned status `unknown(133)`.",
+            translation_placeholders={"status": "unknown(133)"},
+        ),
+    )
+    hass.services.register(
+        "matter",
+        "get_lock_info",
+        {
+            "lock.front_door": {
+                "supports_user_management": True,
+                "supported_credential_types": ["pin"],
+                "max_users": 10,
+                "max_pin_users": 10,
+                "max_credentials_per_user": 1,
+                "min_pin_length": 4,
+                "max_pin_length": 8,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 11, "5678"))
+
+    assert result.verified is False
+    assert result.extra.get("matter_status") == "unknown(133)"
+    assert result.extra.get("reason") == "slot_out_of_range"
+    assert result.extra.get("max_slots") == 10
+    assert result.extra.get("slot") == 11
+    assert "slot_out_of_range" in (result.error or "")
+    assert "max_slots=10" in (result.error or "")
+
+
+def test_matter_set_code_marks_in_range_unknown_133_as_lock_rejected():
+    """When the slot is *within* advertised capacity but the lock still
+    rejects with ``unknown(133)`` (e.g. user table exhausted, lock
+    disagreeing with its own advertised capacity), tag the failure as
+    ``lock_rejected`` rather than ``slot_out_of_range``.
+    """
+    from homeassistant.exceptions import HomeAssistantError
+
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    _register_credential_status(hass, exists=False)
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        HomeAssistantError(
+            "Failed to set credential: lock returned status `unknown(133)`.",
+            translation_placeholders={"status": "unknown(133)"},
+        ),
+    )
+    hass.services.register(
+        "matter",
+        "get_lock_info",
+        {
+            "lock.front_door": {
+                "max_pin_users": 10,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 5, "5678"))
+
+    assert result.verified is False
+    assert result.extra.get("reason") == "lock_rejected"
+    assert result.extra.get("max_slots") == 10
+    assert result.extra.get("slot") == 5
     assert "matter_status=unknown(133)" in (result.error or "")
 
 

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -1,0 +1,292 @@
+"""Tests for the LockProvider abstraction and Matter provider helpers.
+
+These tests exercise pure helpers that don't require a running Home
+Assistant instance — handler routing, response unwrapping, and the
+device-discovery capability heuristic for Matter vs. Z-Wave.
+"""
+
+from __future__ import annotations
+
+# HA module stubs and sys.path setup live in conftest.py.
+
+
+def test_provider_result_default_extra_is_independent_per_instance():
+    from services.lock_provider import ProviderResult
+
+    a = ProviderResult(slot=1, method="x", verified=True)
+    b = ProviderResult(slot=2, method="y", verified=False)
+    a.extra["k"] = "v"
+    assert b.extra == {}, "default factory must give each instance its own dict"
+
+
+def test_slot_info_basic_shape():
+    from services.lock_provider import SlotInfo
+
+    s = SlotInfo(slot=3, occupied=True, code="1234")
+    assert s.slot == 3
+    assert s.occupied is True
+    assert s.code == "1234"
+
+
+def test_capability_info_defaults():
+    from services.lock_provider import CapabilityInfo
+
+    c = CapabilityInfo(supports_access_codes=True)
+    assert c.max_slots is None
+    assert c.extra == {}
+
+
+# ---------------------------------------------------------------------------
+# Matter provider — response unwrapping
+# ---------------------------------------------------------------------------
+
+
+def test_matter_extract_entity_response_returns_per_entity_when_present():
+    from services.providers.matter import _extract_entity_response
+
+    response = {
+        "lock.front_door": {
+            "credential_index": 9,
+            "user_index": 9,
+            "next_credential_index": 10,
+        }
+    }
+    assert _extract_entity_response(response, "lock.front_door") == {
+        "credential_index": 9,
+        "user_index": 9,
+        "next_credential_index": 10,
+    }
+
+
+def test_matter_extract_entity_response_falls_back_to_top_level_when_unkeyed():
+    from services.providers.matter import _extract_entity_response
+
+    response = {"credential_index": 9, "user_index": 9}
+    assert _extract_entity_response(response, "lock.front_door") == response
+
+
+def test_matter_extract_entity_response_handles_none():
+    from services.providers.matter import _extract_entity_response
+
+    assert _extract_entity_response(None, "lock.front_door") is None
+
+
+# ---------------------------------------------------------------------------
+# Device discovery — Matter access-code heuristic
+# ---------------------------------------------------------------------------
+
+
+def test_lock_supports_access_codes_matter_always_true():
+    from lock_capability_heuristics import lock_supports_access_codes
+
+    # Matter locks: trust the integration registration; supported_features
+    # bit 1 is set independently for unbolt support, not credentials.
+    assert lock_supports_access_codes({"supported_features": 0}, "matter") is True
+    assert lock_supports_access_codes({}, "matter") is True
+
+
+def test_lock_supports_access_codes_zwave_uses_supported_features_bit():
+    from lock_capability_heuristics import lock_supports_access_codes
+
+    assert lock_supports_access_codes({"supported_features": 1}, "zwave_js") is True
+    assert lock_supports_access_codes({"supported_features": 0}, "zwave_js") is False
+
+
+def test_lock_supports_access_codes_unknown_protocol_falls_back_to_heuristic():
+    from lock_capability_heuristics import lock_supports_access_codes
+
+    assert lock_supports_access_codes({"supported_features": 1}, None) is True
+    assert lock_supports_access_codes({}, "wifi") is False
+
+
+# ---------------------------------------------------------------------------
+# Matter provider — duplicate-status detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_duplicate_credential_error_via_translation_placeholders():
+    from homeassistant.exceptions import HomeAssistantError
+
+    from services.providers.matter import _is_duplicate_credential_error
+
+    exc = HomeAssistantError(
+        "Failed to set credential: lock returned status `duplicate`.",
+        translation_domain="matter",
+        translation_key="set_credential_failed",
+        translation_placeholders={"status": "duplicate"},
+    )
+    assert _is_duplicate_credential_error(exc) is True
+
+
+def test_is_duplicate_credential_error_via_message_substring():
+    from homeassistant.exceptions import HomeAssistantError
+
+    from services.providers.matter import _is_duplicate_credential_error
+
+    exc = HomeAssistantError(
+        "Failed to set credential: lock returned status `duplicate`."
+    )
+    assert _is_duplicate_credential_error(exc) is True
+
+
+def test_is_duplicate_credential_error_false_for_other_statuses():
+    from homeassistant.exceptions import HomeAssistantError
+
+    from services.providers.matter import _is_duplicate_credential_error
+
+    exc = HomeAssistantError(
+        "Failed to set credential: lock returned status `occupied`.",
+        translation_placeholders={"status": "occupied"},
+    )
+    assert _is_duplicate_credential_error(exc) is False
+
+    other = HomeAssistantError("Some unrelated transport failure")
+    assert _is_duplicate_credential_error(other) is False
+
+
+# ---------------------------------------------------------------------------
+# Matter provider — set_code happy path + duplicate handling
+# ---------------------------------------------------------------------------
+
+
+class _RecordingServices:
+    """Minimal hass.services stand-in that records calls and lets the
+    test queue per-call return values or exceptions.
+    """
+
+    def __init__(self):
+        self.calls: list[tuple[str, str, dict]] = []
+        self._handlers: dict[tuple[str, str], object] = {}
+
+    def register(self, domain, service, handler):
+        self._handlers[(domain, service)] = handler
+
+    async def async_call(
+        self, domain, service, data, *, blocking=True, return_response=False
+    ):
+        self.calls.append((domain, service, dict(data)))
+        handler = self._handlers.get((domain, service))
+        if handler is None:
+            raise AssertionError(
+                f"unexpected service call {domain}.{service} with {data!r}"
+            )
+        if isinstance(handler, BaseException):
+            raise handler
+        if callable(handler):
+            return handler(data)
+        return handler
+
+
+class _FakeHass:
+    def __init__(self):
+        self.services = _RecordingServices()
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_matter_set_code_calls_only_set_lock_credential_on_happy_path():
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        {
+            "lock.front_door": {
+                "credential_index": 7,
+                "user_index": 7,
+                "next_credential_index": 8,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 7, "1234"))
+
+    assert [(d, s) for d, s, _ in hass.services.calls] == [
+        ("matter", "set_lock_credential")
+    ]
+    set_call_data = hass.services.calls[0][2]
+    assert set_call_data["credential_index"] == 7
+    assert set_call_data["user_index"] == 7
+    assert set_call_data["credential_data"] == "1234"
+
+    assert result.verified is True
+    assert result.method == "matter_set_credential"
+    assert result.extra["credential_index"] == 7
+
+
+def test_matter_set_code_treats_duplicate_status_as_verified():
+    from homeassistant.exceptions import HomeAssistantError
+
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        HomeAssistantError(
+            "Failed to set credential: lock returned status `duplicate`.",
+            translation_placeholders={"status": "duplicate"},
+        ),
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 7, "1234"))
+
+    assert result.verified is True
+    assert result.method == "matter_set_credential_duplicate"
+    assert result.extra.get("status") == "duplicate"
+    assert result.error is None
+
+
+def test_matter_set_code_surfaces_non_duplicate_error_as_failure():
+    from homeassistant.exceptions import HomeAssistantError
+
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        HomeAssistantError(
+            "Failed to set credential: lock returned status `occupied`.",
+            translation_placeholders={"status": "occupied"},
+        ),
+    )
+
+    provider = MatterLockProvider()
+    result = _run(provider.set_code(hass, "lock.front_door", 7, "1234"))
+
+    assert result.verified is False
+    assert "set_lock_credential" in (result.error or "")
+
+
+def test_matter_set_code_does_not_call_set_lock_user():
+    """Regression guard: dropping ``set_lock_user`` is what unblocked
+    the Bolt SE; this test fails loudly if anyone reintroduces it.
+    """
+    from services.providers.matter import MatterLockProvider
+
+    hass = _FakeHass()
+    hass.services.register(
+        "matter",
+        "set_lock_credential",
+        {
+            "lock.front_door": {
+                "credential_index": 1,
+                "user_index": 1,
+                "next_credential_index": 2,
+            }
+        },
+    )
+
+    provider = MatterLockProvider()
+    _run(provider.set_code(hass, "lock.front_door", 1, "9999"))
+
+    services_called = {(d, s) for d, s, _ in hass.services.calls}
+    assert ("matter", "set_lock_user") not in services_called

--- a/tests/test_lock_access_codes.py
+++ b/tests/test_lock_access_codes.py
@@ -492,297 +492,19 @@ def test_matter_set_code_marks_in_range_unknown_133_as_lock_rejected():
     assert "matter_status=unknown(133)" in (result.error or "")
 
 
-def test_matter_set_code_add_path_with_max_credentials_per_user_one_skips_user_index():
-    """Locks that report ``max_credentials_per_user`` of 1 (or omit the
-    field entirely) get the pre-stacking behaviour: no probe, ``user_index``
-    omitted on the wire, ``user_type`` set so the lock auto-allocates a
-    fresh user.
-    """
-    from services.providers.matter import MatterLockProvider
-
-    hass = _FakeHass()
-    _register_credential_status(hass, exists=False)
-    hass.services.register(
-        "matter",
-        "get_lock_info",
-        {
-            "lock.front_door": {
-                "supports_user_management": True,
-                "supported_credential_types": ["pin"],
-                "max_pin_users": 30,
-                "max_credentials_per_user": 1,
-            }
-        },
-    )
-    hass.services.register(
-        "matter",
-        "set_lock_credential",
-        {
-            "lock.front_door": {
-                "credential_index": 3,
-                "user_index": 3,
-                "next_credential_index": 4,
-            }
-        },
-    )
-
-    provider = MatterLockProvider()
-    _run(provider.set_code(hass, "lock.front_door", 3, "1234"))
-
-    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
-    set_data = set_call[2]
-    assert "user_index" not in set_data
-    assert set_data.get("user_type") == "unrestricted_user"
-    assert "user_status" not in set_data
-    # No additional credential_status probes beyond the preflight.
-    status_calls = [c for c in hass.services.calls if c[1] == "get_lock_credential_status"]
-    assert len(status_calls) == 1
-
-
-def test_matter_set_code_add_path_in_fresh_user_group_lets_lock_auto_allocate():
-    """Stacked lock (Bolt SE-style: ``max_credentials_per_user=5``).
-    First credential of a fresh user-group means no sibling is occupied,
-    so we fall back to the auto-allocate shape: ``user_index`` omitted,
-    ``user_type`` set.  Probes the other 4 slots in the group looking
-    for an occupant before deciding.
-    """
-    from services.providers.matter import MatterLockProvider
-
-    hass = _FakeHass()
-
-    def _credential_status_stub(data):
-        # All probes return empty — fresh user-group.
-        return {
-            "lock.front_door": {
-                "credential_exists": False,
-                "user_index": None,
-                "next_credential_index": None,
-            }
-        }
-
-    hass.services.register(
-        "matter", "get_lock_credential_status", _credential_status_stub
-    )
-    hass.services.register(
-        "matter",
-        "get_lock_info",
-        {
-            "lock.front_door": {
-                "supports_user_management": True,
-                "supported_credential_types": ["pin"],
-                "max_pin_users": 10,
-                "max_credentials_per_user": 5,
-            }
-        },
-    )
-    hass.services.register(
-        "matter",
-        "set_lock_credential",
-        {
-            "lock.front_door": {
-                "credential_index": 6,
-                "user_index": 2,  # lock auto-allocated
-                "next_credential_index": 7,
-            }
-        },
-    )
-
-    provider = MatterLockProvider()
-    result = _run(provider.set_code(hass, "lock.front_door", 6, "1234"))
-
-    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
-    set_data = set_call[2]
-    assert "user_index" not in set_data, (
-        "Fresh user-group must omit user_index so the lock auto-allocates"
-    )
-    assert set_data.get("user_type") == "unrestricted_user"
-    assert "user_status" not in set_data
-
-    # Slot 6 + probes for slots 7, 8, 9, 10 = 5 credential_status calls
-    status_slots = [
-        c[2]["credential_index"]
-        for c in hass.services.calls
-        if c[1] == "get_lock_credential_status"
-    ]
-    assert sorted(status_slots) == [6, 7, 8, 9, 10]
-    assert result.verified is True
-    assert result.extra["user_index"] == 2
-
-
-def test_matter_set_code_add_path_in_existing_user_group_attaches_to_user():
-    """Stacked lock, second credential in a user-group: probe finds the
-    sibling slot already occupied with ``user_index=1``, so we send
-    ``user_index=1`` and **omit** ``user_type``/``user_status`` — this
-    is "Add credential to existing user", which the Bolt SE accepts.
-    """
-    from services.providers.matter import MatterLockProvider
-
-    hass = _FakeHass()
-
-    def _credential_status_stub(data):
-        slot = data["credential_index"]
-        if slot == 1:
-            # sibling in the same user-group, already programmed
-            return {
-                "lock.front_door": {
-                    "credential_exists": True,
-                    "user_index": 1,
-                    "next_credential_index": 3,
-                }
-            }
-        return {
-            "lock.front_door": {
-                "credential_exists": False,
-                "user_index": None,
-                "next_credential_index": None,
-            }
-        }
-
-    hass.services.register(
-        "matter", "get_lock_credential_status", _credential_status_stub
-    )
-    hass.services.register(
-        "matter",
-        "get_lock_info",
-        {
-            "lock.front_door": {
-                "supports_user_management": True,
-                "supported_credential_types": ["pin"],
-                "max_pin_users": 10,
-                "max_credentials_per_user": 5,
-            }
-        },
-    )
-    hass.services.register(
-        "matter",
-        "set_lock_credential",
-        {
-            "lock.front_door": {
-                "credential_index": 2,
-                "user_index": 1,  # attached to existing user
-                "next_credential_index": 3,
-            }
-        },
-    )
-
-    provider = MatterLockProvider()
-    result = _run(provider.set_code(hass, "lock.front_door", 2, "1234"))
-
-    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
-    set_data = set_call[2]
-    assert set_data.get("user_index") == 1, (
-        "Existing user-group: must send the discovered user_index"
-    )
-    assert "user_type" not in set_data, (
-        "Existing user-group: user_type/user_status must be null on the wire"
-    )
-    assert "user_status" not in set_data
-    assert result.verified is True
-    assert result.extra["operation"] == "add"
-    assert result.extra["user_index"] == 1
-
-
-def test_matter_set_code_stacking_short_circuits_on_first_occupied_sibling():
-    """The probe walks slots in order and stops at the first occupied
-    one — important for keeping the per-Add cost bounded by the first
-    occupant rather than always scanning the whole group.
-    """
-    from services.providers.matter import MatterLockProvider
-
-    hass = _FakeHass()
-
-    def _credential_status_stub(data):
-        slot = data["credential_index"]
-        if slot == 1:
-            return {
-                "lock.front_door": {
-                    "credential_exists": True,
-                    "user_index": 7,
-                }
-            }
-        return {
-            "lock.front_door": {"credential_exists": False, "user_index": None}
-        }
-
-    hass.services.register(
-        "matter", "get_lock_credential_status", _credential_status_stub
-    )
-    hass.services.register(
-        "matter",
-        "get_lock_info",
-        {
-            "lock.front_door": {
-                "max_pin_users": 10,
-                "max_credentials_per_user": 5,
-            }
-        },
-    )
-    hass.services.register(
-        "matter",
-        "set_lock_credential",
-        {"lock.front_door": {"credential_index": 5, "user_index": 7}},
-    )
-
-    provider = MatterLockProvider()
-    _run(provider.set_code(hass, "lock.front_door", 5, "1234"))
-
-    # Preflight (slot 5) + probe slot 1 (occupant found, stop).
-    status_slots = [
-        c[2]["credential_index"]
-        for c in hass.services.calls
-        if c[1] == "get_lock_credential_status"
-    ]
-    assert status_slots == [5, 1], (
-        "Probe must short-circuit at the first occupied sibling, not "
-        "scan all 4 remaining slots"
-    )
-
-
-def test_matter_modify_path_unaffected_by_stacking_capabilities():
-    """Modify path always uses the queried user_index regardless of
-    ``max_credentials_per_user`` — the credential already exists, no
-    user-group probing needed.
-    """
-    from services.providers.matter import MatterLockProvider
-
-    hass = _FakeHass()
-    _register_credential_status(hass, exists=True, user_index=42)
-    hass.services.register(
-        "matter",
-        "set_lock_credential",
-        {"lock.front_door": {"credential_index": 7, "user_index": 42}},
-    )
-
-    provider = MatterLockProvider()
-    result = _run(provider.set_code(hass, "lock.front_door", 7, "1234"))
-
-    set_call = next(c for c in hass.services.calls if c[1] == "set_lock_credential")
-    set_data = set_call[2]
-    assert set_data["user_index"] == 42
-    assert "user_type" not in set_data
-
-    # Modify must NOT call get_lock_info (no need for stacking caps).
-    info_calls = [c for c in hass.services.calls if c[1] == "get_lock_info"]
-    assert info_calls == []
-    # And must NOT probe siblings.
-    status_calls = [
-        c for c in hass.services.calls if c[1] == "get_lock_credential_status"
-    ]
-    assert len(status_calls) == 1
-    assert result.extra["operation"] == "modify"
-
-
 def test_matter_get_capabilities_exposes_max_users_and_credentials_per_user():
     """``get_capabilities`` must surface all three Matter capacity caps so
-    Orion's CapabilityLearner can persist them: ``max_users``,
-    ``max_credentials_per_user``, and the derived ``max_slots``.
+    Orion's CapabilityLearner can persist them as telemetry:
+    ``max_users``, ``max_credentials_per_user``, and the derived
+    ``max_slots``.
 
     ``max_slots`` is conservative — equal to ``max_users`` even when
     the lock advertises ``max_credentials_per_user >= 2`` — because
-    real-world firmware (Ultraloq Bolt SE) caps global credentials at
-    the user count regardless of the spec's implied ``U × C`` ceiling.
-    Catalogued locks that genuinely support the full product can
-    override via ``SupportedDevice.default_settings`` in Orion.
+    real-world firmware (Ultraloq Bolt SE) caps global PIN credentials
+    at the user count regardless of the spec's implied ``U × C``
+    ceiling.  Catalogued locks that genuinely support the full
+    product can override via ``SupportedDevice.default_settings`` in
+    Orion.
     """
     from services.providers.matter import MatterLockProvider
 
@@ -808,17 +530,15 @@ def test_matter_get_capabilities_exposes_max_users_and_credentials_per_user():
     assert caps.max_users == 10
     assert caps.max_credentials_per_user == 5
     assert caps.max_slots == 10, (
-        "max_slots must be conservative (== max_users) — the "
-        "max_credentials_per_user cap is consumed by the user-stacking "
-        "branch in set_code, not multiplied into max_slots, because "
-        "vendor firmware caps global PIN credentials at max_users in "
-        "practice (Bolt SE)"
+        "max_slots must be conservative (== max_users) because vendor "
+        "firmware caps global PIN credentials at max_users in practice "
+        "(Bolt SE)"
     )
 
 
-def test_matter_get_capabilities_falls_back_to_max_users_without_stacking():
-    """Locks that report ``max_credentials_per_user`` <= 1 (or omit it)
-    pre-stacking-style: ``max_slots`` equals ``max_users``.
+def test_matter_get_capabilities_falls_back_to_max_users_when_per_user_cap_is_one():
+    """Locks that report ``max_credentials_per_user`` of 1 (or omit it)
+    still report ``max_slots`` equal to ``max_users``.
     """
     from services.providers.matter import MatterLockProvider
 

--- a/tests/test_provider_select.py
+++ b/tests/test_provider_select.py
@@ -1,0 +1,73 @@
+"""Tests for ``services.providers.select_provider`` registry resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _hass_with_device(identifiers: list[tuple[str, str]]):
+    """Build hass + registry mocks so ``entity_id`` resolves to *identifiers*."""
+    hass = MagicMock(name="hass")
+    entity_entry = MagicMock()
+    entity_entry.device_id = "device-uuid-1"
+
+    device = MagicMock()
+    device.identifiers = identifiers
+
+    entity_reg = MagicMock()
+    entity_reg.async_get = MagicMock(return_value=entity_entry)
+    dev_reg = MagicMock()
+    dev_reg.async_get = MagicMock(return_value=device)
+
+    def er_factory(_h):
+        return entity_reg
+
+    def dr_factory(_h):
+        return dev_reg
+
+    return hass, er_factory, dr_factory
+
+
+def test_select_provider_matter_lock():
+    from services.providers import select_provider
+
+    hass, er_factory, dr_factory = _hass_with_device([("matter", "abc")])
+
+    with patch("services.providers.er.async_get", er_factory), patch(
+        "services.providers.dr.async_get", dr_factory
+    ):
+        provider = select_provider(hass, "lock.front_door")
+    assert provider.name == "matter"
+
+
+def test_select_provider_zwave_lock():
+    from services.providers import select_provider
+
+    hass, er_factory, dr_factory = _hass_with_device([("zwave_js", "999-8")])
+
+    with patch("services.providers.er.async_get", er_factory), patch(
+        "services.providers.dr.async_get", dr_factory
+    ):
+        provider = select_provider(hass, "lock.front_door")
+    assert provider.name == "zwave"
+
+
+def test_select_provider_first_matching_domain_wins():
+    """Iteration order over identifiers picks the first supported integration."""
+    from services.providers import select_provider
+
+    hass, er_factory, dr_factory = _hass_with_device(
+        [("matter", "m1"), ("zwave_js", "z1")]
+    )
+
+    with patch("services.providers.er.async_get", er_factory), patch(
+        "services.providers.dr.async_get", dr_factory
+    ):
+        assert select_provider(hass, "lock.a").name == "matter"
+
+    hass2, er2, dr2 = _hass_with_device([("zwave_js", "z1"), ("matter", "m1")])
+
+    with patch("services.providers.er.async_get", er2), patch(
+        "services.providers.dr.async_get", dr2
+    ):
+        assert select_provider(hass2, "lock.b").name == "zwave"


### PR DESCRIPTION
## Summary

Adds first-class support for Matter locks (HA 2026.4 lock manager) and
refactors lock operations behind a protocol-agnostic `LockProvider`
abstraction so Z-Wave and Matter share the same API contract upstream.

Also lands two small gateway-only debugging primitives (`ha_service_call`
passthrough and `tap_events` bus listener) that were needed to iterate
on Matter behavior against real devices.

## What's new

- **Matter lock support** — new `MatterLockProvider` implementing
  `set_code` / `clear_code` / `read_codes` / `get_capabilities` against
  the HA Matter lock manager (`SetCredential`, `ClearCredential`,
  `GetCredentialStatus`).
- **Protocol-agnostic `LockProvider` abstraction**
  (`services/lock_provider.py`) with typed `ProviderResult`, `SlotInfo`,
  and `CapabilityInfo` shapes so cloud/API responses are identical
  regardless of the underlying protocol.
- **Provider selection** via device-registry identifiers
  (`services/providers/__init__.py`) — no more guessing protocol from
  `entity_id`, which is unreliable for Matter.
- **Capability handler is protocol-aware** (`handlers/capability.py`):
  reports `protocol`, `supports_access_codes`, and `max_slots` from the
  selected provider; falls back to legacy Z-Wave node info for other
  domains.
- **PIN slot capacity heuristics** (`lock_capability_heuristics.py`) —
  empirical PIN-slot discovery for Matter locks where vendor-reported
  caps are unreliable.
- **`ha_service_call` passthrough** (`handlers/passthrough.py`) — generic
  authenticated `hass.services.async_call` over the gateway channel for
  troubleshooting and tests. Not exposed on the public webhook surface.
- **`tap_events` action** (`handlers/event_tap.py`) — bounded
  (duration- and count-capped) `hass.bus` subscription returning
  whatever fires in the window, for empirically observing integration
  events from a gateway client.
- **Manifest:** declares `matter` in `after_dependencies` and sets
  `"homeassistant": "2026.4.0"` (Matter lock manager requires it).

## Refactor / internal changes

- `services/zwave.py` -> `services/providers/zwave.py`, reshaped to
  implement the `LockProvider` protocol (behavior unchanged for Z-Wave
  callers; same `set_and_verify` flow, same node-info exposure).
- `handlers/lock.py` no longer calls `zwave_js.set_lock_usercode`
  directly — it picks a provider per entity. Cloud-facing JSON shape is
  unchanged.
- `handlers/device_discovery.py` and `handlers/diagnostics.py` updated
  to the new provider import paths.

## Compatibility

- **Minimum Home Assistant: 2026.4.0** (bumped from previously
  unspecified). Required for the Matter lock manager surface this
  integration relies on. Older HA installs will fail to load — this is
  intentional rather than silently misbehaving.
- Z-Wave behavior, webhook payload shape, and gateway command/response
  shapes are unchanged for existing users.

## Known limitation

Through HA 2026.4, the Matter integration does not expose
per-credential lock-operation events on `hass.bus` the way Z-Wave does.
Forwarded `lock_activity` for Matter is therefore lower fidelity than
Z-Wave (mostly `locked` / `unlocked` transitions). Programming
operations still return structured success/failure inline.

## Testing

- New tests:
  - `tests/test_event_tap.py` — duration/count caps, filtering,
    overflow, cancellation
  - `tests/test_lock_access_codes.py` — Z-Wave + Matter set/clear/read
    paths, capability discovery, error mapping
  - `tests/test_provider_select.py` — device-registry-based protocol
    inference and `UnsupportedProtocolError` paths
- Existing test suite continues to pass.
- Verified end-to-end on a real Matter lock (set/clear/read) and a real
  Z-Wave 700-series lock (regression).

## Release

Beta has been validated through `1.6.0-beta.13`. Squash-merging this
branch will produce the `1.6.0` release via semantic-release.